### PR TITLE
Remove Escape Characters from File Path

### DIFF
--- a/src/Lumper/BSP/BspFile.cs
+++ b/src/Lumper/BSP/BspFile.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Lumper.Lib.BSP.Lumps;
 using Lumper.Lib.BSP.Lumps.BspLumps;
 using Lumper.Lib.BSP.IO;
+using System;
 
 namespace Lumper.Lib.BSP
 {
@@ -34,7 +35,7 @@ namespace Lumper.Lib.BSP
         {
             // TODO: loads of error handling
             Name = Path.GetFileNameWithoutExtension(path);
-            var filePath = Path.GetFullPath(path);
+            var filePath = Uri.UnescapeDataString(Path.GetFullPath(path));
             var stream = File.OpenRead(filePath);
             Load(stream);
             //set this at the end because Load(stream) resets it


### PR DESCRIPTION
Lumper was not loading files properly due to an invalid file path being used when initializing the bsp file object. For instance loading arena_offblast_final would result in the file path:
`C:\Program%20Files%20(x86)\Steam\steamapps\common\Team%20Fortress%202\tf\maps\arena_offblast_final.bsp`
The file would fail to open (on windows) with the escape characters in place of the spaces. The fix for this is to strip these to provide 
`C:\Program Files (x86)\Steam\steamapps\common\Team Fortress 2\tf\maps\arena_offblast_final.bsp`
using C#'s Uri features.