### PR TITLE
Fix/bspconvert

### DIFF
--- a/src/Lumper/BSP/IO/BspFileReader.cs
+++ b/src/Lumper/BSP/IO/BspFileReader.cs
@@ -14,10 +14,11 @@ namespace Lumper.Lib.BSP.IO
         [JsonIgnore]
         private readonly BspFile _bsp;
 
-        public override IReadOnlyDictionary<System.Enum, LumpHeader> Headers
+        [JsonProperty]
+        public IReadOnlyDictionary<BspLumpType, LumpHeader> Headers
         {
             get => Lumps.ToDictionary(
-                x => (System.Enum)(x.Item1 is Lump<BspLumpType> lump
+                x => (x.Item1 is Lump<BspLumpType> lump
                                 ? lump.Type
                                 : BspLumpType.Unknown),
                 x => x.Item2);

--- a/src/Lumper/BSP/IO/GameLumpReader.cs
+++ b/src/Lumper/BSP/IO/GameLumpReader.cs
@@ -15,10 +15,11 @@ namespace Lumper.Lib.BSP.IO
         private readonly GameLump _gameLump;
         private readonly long _length;
 
-        public override IReadOnlyDictionary<System.Enum, LumpHeader> Headers
+        [JsonProperty]
+        public IReadOnlyDictionary<GameLumpType, LumpHeader> Headers
         {
             get => Lumps.ToDictionary(
-                x => (System.Enum)(x.Item1 is Lump<GameLumpType> lump
+                x => (x.Item1 is Lump<GameLumpType> lump
                                 ? lump.Type
                                 : GameLumpType.Unknown),
                 x => x.Item2);

--- a/src/Lumper/BSP/IO/LumpReader.cs
+++ b/src/Lumper/BSP/IO/LumpReader.cs
@@ -17,9 +17,6 @@ namespace Lumper.Lib.BSP.IO
         // lumpheader information is only needed in the reader
         protected List<Tuple<Lump, LumpHeader>> Lumps = new();
 
-        [JsonProperty]
-        public abstract IReadOnlyDictionary<System.Enum, LumpHeader> Headers { get; }
-
         public LumpReader(Stream input) : base(input)
         { }
         protected abstract void ReadHeader();

--- a/src/Lumper/BSP/Lumps/GameLumps/GameLumpType.cs
+++ b/src/Lumper/BSP/Lumps/GameLumps/GameLumpType.cs
@@ -9,5 +9,6 @@ namespace Lumper.Lib.BSP.Lumps.GameLumps
         dprp = 0x64707270, // detail prop
         dplt = 0x64706c74, // detail prop lighting LDR
         dplh = 0x64706c68, // detail prop lighting HDR
+        pmti = 0x706d7469, // (1886221417) from BSPConvert
     }
 }


### PR DESCRIPTION
closes #24 

Fixed the bug and added the new gamelump type to the enum. Didn't get it to work with the abstract method and `System.Enum` so I just removed it in the end. I could have changed the key to string instead, but its only used for the JSON export so its not really necessary.