### PR TITLE
fix: set FilePath when creating BspViewModel

### DIFF
--- a/src/Lumper.UI/ViewModels/Bsp/BspViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Bsp/BspViewModel.cs
@@ -14,6 +14,7 @@ public partial class BspViewModel : ViewModelBase
     public BspViewModel(BspFile bspFile)
     {
         BspFile = bspFile;
+        FilePath = BspFile.FilePath;
         BspNode = new BspNodeViewModel(this);
         SearchInit();
         TabsInit();

--- a/src/Lumper.UI/ViewModels/Bsp/BspViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Bsp/BspViewModel.cs
@@ -4,17 +4,22 @@ using Lumper.UI.ViewModels.Bsp.Lumps;
 
 namespace Lumper.UI.ViewModels.Bsp;
 
+using System.IO;
+
 /// <summary>
 ///     View model for <see cref="Lumper.Lib.BSP.BspFile" />
 /// </summary>
 public partial class BspViewModel : ViewModelBase
 {
     private string? _filePath;
+    private string? _fileName;
 
     public BspViewModel(BspFile bspFile)
     {
         BspFile = bspFile;
+
         FilePath = BspFile.FilePath;
+        FileName = Path.GetFileNameWithoutExtension(BspFile.FilePath);
         BspNode = new BspNodeViewModel(this);
         SearchInit();
         TabsInit();
@@ -41,6 +46,13 @@ public partial class BspViewModel : ViewModelBase
         get => _filePath;
         set => this.RaiseAndSetIfChanged(ref _filePath, value);
     }
+
+    public string? FileName
+    {
+        get => _fileName;
+        set => this.RaiseAndSetIfChanged(ref _fileName, value);
+    }
+
 
     public void Update()
     {

--- a/src/Lumper.UI/Views/MainWindow.axaml
+++ b/src/Lumper.UI/Views/MainWindow.axaml
@@ -9,7 +9,7 @@
         x:Class="Lumper.UI.Views.MainWindow"
         Icon="/Assets/Lumper.png"
         Closing="Window_OnClosing"
-        Title="{Binding BspModel.FilePath, StringFormat='{}Lumper {0}'}"
+        Title="{Binding BspModel.FileName, StringFormat='Lumper - {0}',  FallbackValue='Lumper'}"
         TransparencyLevelHint="AcrylicBlur"
         ExtendClientAreaToDecorationsHint="True"
         WindowStartupLocation="CenterScreen"


### PR DESCRIPTION
Closes #20.
This also fixes the save button opening the file picker instead of saving the currently opened file.