### PR TITLE
Add texture browser

### DIFF
--- a/src/Lumper.UI/Lumper.UI.csproj
+++ b/src/Lumper.UI/Lumper.UI.csproj
@@ -11,7 +11,6 @@
     </PropertyGroup>
     <ItemGroup>
         <Folder Include="Dependencies\Linux\" />
-        <Folder Include="Models\" />
         <AvaloniaResource Include="Assets\**" />
         <None Remove=".gitignore" />
     </ItemGroup>
@@ -31,6 +30,7 @@
         <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview4" />
         <PackageReference Include="Glob" Version="1.2.0-alpha0037" />
         <PackageReference Include="MessageBox.Avalonia" Version="2.3.1-prev2" />
+        <PackageReference Include="ReactiveUI" Version="19.5.39" />
         <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
         <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
     </ItemGroup>

--- a/src/Lumper.UI/Models/Vtf/VtfFileData.cs
+++ b/src/Lumper.UI/Models/Vtf/VtfFileData.cs
@@ -1,0 +1,190 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using VTFLib;
+using Lumper.Lib.BSP.Struct;
+
+namespace Lumper.UI.Models;
+
+public class VtfFileData
+{
+    private readonly PakFileEntry _entry;
+    private readonly uint _imageIndex;
+
+    private uint _frameCount;
+    private uint _faceCount;
+    private uint _mipmapCount;
+    private uint _depth;
+    private VTFImageFlag _flags;
+    private uint _majorVersion;
+    private uint _minorVersion;
+    private uint _imageSize;
+    private uint _imageWidth;
+    private uint _imageHeight;
+    private VTFImageFormat _imageFormat;
+
+    public uint FrameCount => _frameCount;
+    public uint FaceCount => _faceCount;
+    public uint MipmapCount => _mipmapCount;
+    public uint Depth => _depth;
+    public VTFImageFlag Flags => _flags;
+    public uint MajorVersion => _majorVersion;
+    public uint MinorVersion => _minorVersion;
+    public uint ImageSize => _imageSize;
+    public uint ImageWidth => _imageWidth;
+    public uint ImageHeight => _imageHeight;
+    public VTFImageFormat ImageFormat => _imageFormat;
+
+    static VtfFileData()
+    {
+        VTFAPI.Initialize();
+    }
+    public VtfFileData(PakFileEntry entry)
+    {
+        _entry = entry;
+        using var mem = new MemoryStream();
+        _entry.DataStream.CopyTo(mem);
+        byte[] vtfBuffer = mem.ToArray();
+
+        VTFFile.CreateImage(ref _imageIndex);
+
+        VTFFile.BindImage(_imageIndex);
+        VTFFile.ImageLoadLump(vtfBuffer, (uint)vtfBuffer.Length, false);
+
+        Update();
+    }
+
+    public Image<Rgba32>? GetImage(uint frame, uint face, uint slice, uint mipmapLevel)
+    {
+        VTFFile.BindImage(_imageIndex);
+
+        if (VTFFile.ImageGetHasImage() == 0)
+        {
+            return null;
+        }
+
+        IntPtr imageData = VTFFile.ImageGetData(frame, face, slice, mipmapLevel);
+        int imageSize = (int)VTFFile.ImageComputeImageSize(_imageWidth, _imageHeight, 1, 1, _imageFormat);
+
+        byte[] data = new byte[imageSize];
+        Marshal.Copy(imageData, data, 0, imageSize);
+
+        if (imageSize <= 0)
+            throw new ArgumentException("image data array size is 0");
+        byte[] dest = new byte[_imageWidth * _imageHeight * 4];
+        VTFFile.ImageConvertToRGBA8888(data, dest, _imageWidth, _imageHeight, _imageFormat);
+
+        var rgba = new Rgba32[_imageWidth * _imageHeight];
+        int j = 0;
+        for(int i = 0; i < dest.Length; i += 4)
+        {
+            rgba[j++] = new Rgba32(
+                dest[i],
+                dest[i + 1],
+                dest[i + 2],
+                dest[i + 3]);
+        }
+
+        return Image.LoadPixelData<Rgba32>(rgba.AsSpan(), (int)_imageWidth, (int)_imageHeight);
+    }
+
+    public void SetImageData(Image<Rgba32> image, uint frame, uint face, uint slice, uint mipmapLevel)
+    {
+        VTFFile.BindImage(_imageIndex);
+        byte[] imageRgbaData = GetRgba8888FromImage(image, out _);
+
+        int size = (int)VTFFile.ImageComputeImageSize(
+            (uint)image.Width, (uint)image.Height, 1, 1, _imageFormat);
+        byte[] vtfImageData = new byte[size];
+
+        VTFFile.ImageConvertFromRGBA8888(
+            imageRgbaData,
+            vtfImageData,
+            (uint)image.Width,
+            (uint)image.Height,
+            _imageFormat
+        );
+
+        VTFFile.ImageSetData(frame, face, slice, mipmapLevel, vtfImageData);
+        SaveVtf();
+    }
+
+    public void SetNewImage(Image<Rgba32> image)
+    {
+        VTFFile.BindImage(_imageIndex);
+        byte[] buffer = GetRgba8888FromImage(image, out bool hasAlpha);
+        var createOptions = new SVTFCreateOptions();
+        VTFFile.ImageCreateDefaultCreateStructure(ref createOptions);
+        createOptions.imageFormat =
+            hasAlpha ? VTFImageFormat.IMAGE_FORMAT_DXT5 : VTFImageFormat.IMAGE_FORMAT_DXT1;
+        if (!VTFFile.ImageCreateSingle(
+                (uint)image.Width,
+                (uint)image.Height,
+                buffer,
+                ref createOptions))
+        {
+            string err = VTFAPI.GetLastError();
+            Console.WriteLine(err);
+        }
+
+        SaveVtf();
+    }
+
+    private void SaveVtf()
+    {
+        uint size = VTFFile.ImageGetSize();
+
+        var vtfBuffer = new byte[size];
+        _entry.DataStream = new MemoryStream(vtfBuffer);
+
+        uint uiSize = 0;
+        if (!VTFFile.ImageSaveLump(vtfBuffer, (uint)vtfBuffer.Length, ref uiSize))
+        {
+            string err = VTFAPI.GetLastError();
+            Console.WriteLine(err);
+        }
+
+        _entry.DataStream.Seek(0, SeekOrigin.Begin);
+        Update();
+    }
+
+    private void Update()
+    {
+        _depth = VTFFile.ImageGetDepth();
+        _frameCount = VTFFile.ImageGetFrameCount();
+        _faceCount = VTFFile.ImageGetFaceCount();
+        _mipmapCount = VTFFile.ImageGetMipmapCount();
+        _flags = (VTFImageFlag)VTFFile.ImageGetFlags();
+        _majorVersion = VTFFile.ImageGetMajorVersion();
+        _minorVersion = VTFFile.ImageGetMinorVersion();
+        _imageSize = VTFFile.ImageGetSize();
+        _imageWidth = VTFFile.ImageGetWidth();
+        _imageHeight = VTFFile.ImageGetHeight();
+        _imageFormat = VTFFile.ImageGetFormat();
+    }
+
+    private static byte[] GetRgba8888FromImage(Image<Rgba32> image, out bool hasAlpha)
+    {
+        int size = image.Width * image.Height * 4;
+        using var mem = new MemoryStream();
+        var buffer = new byte[size];
+        int i = 0;
+        hasAlpha = false;
+        for (int y = 0; y < image.Height; y++)
+        {
+            for (int x = 0; x < image.Width; x++)
+            {
+                Rgba32 pixel = image[x, y];
+                buffer[i++] = pixel.R;
+                buffer[i++] = pixel.G;
+                buffer[i++] = pixel.B;
+                buffer[i++] = pixel.A;
+                if (!hasAlpha && pixel.A != 255)
+                    hasAlpha = true;
+            }
+        }
+        return buffer;
+    }
+}

--- a/src/Lumper.UI/ViewModels/Bsp/BspViewModel.Search.cs
+++ b/src/Lumper.UI/ViewModels/Bsp/BspViewModel.Search.cs
@@ -33,7 +33,7 @@ public partial class BspViewModel
     }
 
     private static async void Search(
-        (string?, MatcherBase?, BspNodeBase?) args)
+        (string?, MatcherBase?, BspNodeBase) args)
     {
         (string? pattern, var matcherBase, var bspNode) = args;
         if (matcherBase is null || pattern is null)

--- a/src/Lumper.UI/ViewModels/Bsp/Lumps/Entity/EntityLumpViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Bsp/Lumps/Entity/EntityLumpViewModel.cs
@@ -59,7 +59,7 @@ public class EntityLumpViewModel : LumpBase
     }
 
 
-    public void Open()
+    public override void Open()
     {
         using var mem = new MemoryStream();
         _entityLump.Write(mem);

--- a/src/Lumper.UI/ViewModels/Bsp/Lumps/PakFile/PakFileEntryVtfViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Bsp/Lumps/PakFile/PakFileEntryVtfViewModel.cs
@@ -1,11 +1,12 @@
 using System;
 using System.IO;
-using System.Runtime.InteropServices;
+using Lumper.Lib.BSP.Struct;
+using Lumper.UI.Models;
+using Lumper.UI.ViewModels.VtfBrowser;
 using ReactiveUI;
-using VTFLib;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-using Lumper.Lib.BSP.Struct;
+using VTFLib;
 
 namespace Lumper.UI.ViewModels.Bsp.Lumps.PakFile;
 
@@ -23,6 +24,7 @@ public class PakFileEntryVtfViewModel : PakFileEntryLeafViewModel
         $"PakFileEntry{(string.IsNullOrWhiteSpace(Name) ? "" : $" ({Name})")}";
 
     private string _info = "";
+
     public string Info
     {
         get => _info;
@@ -30,9 +32,11 @@ public class PakFileEntryVtfViewModel : PakFileEntryLeafViewModel
     }
 
     private bool _isModified = false;
-    public override bool IsModified { get => _isModified; }
 
-    public Image<Rgba32>? _image = null;
+    public override bool IsModified => _isModified;
+
+    private Image<Rgba32>? _image = null;
+
     public Image<Rgba32>? Image
     {
         get => _image;
@@ -40,181 +44,85 @@ public class PakFileEntryVtfViewModel : PakFileEntryLeafViewModel
     }
 
     private uint _frame;
+
     public uint Frame
     {
         get => _frame;
         private set
         {
             this.RaiseAndSetIfChanged(ref _frame, value);
-            OpenImage();
+            UpdateImage();
         }
     }
 
-    public uint _face;
+    private uint _face;
+
     public uint Face
     {
         get => _face;
         private set
         {
             this.RaiseAndSetIfChanged(ref _face, value);
-            OpenImage();
+            UpdateImage();
         }
     }
 
-    public uint _slice;
+    private uint _slice;
+
     public uint Slice
     {
         get => _slice;
         private set
         {
             this.RaiseAndSetIfChanged(ref _slice, value);
-            OpenImage();
+            UpdateImage();
         }
     }
 
-    public uint _mipmapLevel;
+    private uint _mipmapLevel;
+
     public uint MipmapLevel
     {
         get => _mipmapLevel;
         private set
         {
             this.RaiseAndSetIfChanged(ref _mipmapLevel, value);
-            OpenImage();
+            UpdateImage();
         }
     }
 
-    private uint _depth;
-    public uint Depth
-    {
-        get => _depth;
-        private set => this.RaiseAndSetIfChanged(ref _depth, value);
-    }
+    public uint FrameMax => _vtfData?.FrameCount - 1 ?? 0;
+    public uint FaceMax => _vtfData?.FaceCount - 1 ?? 0;
+    public uint MipmapMax => _vtfData?.MipmapCount - 1 ?? 0;
 
-    private uint _frameCount;
-    public uint FrameCount
-    {
-        get => _frameCount;
-        private set
-        {
-            if (_frameCount != value)
-            {
-                _frameCount = value;
-                this.RaisePropertyChanged();
-                this.RaisePropertyChanged(nameof(FrameMax));
-            }
-        }
-    }
-    public uint FrameMax { get { return FrameCount - 1; } }
+    private VtfFileData? _vtfData;
 
-    private uint _faceCount;
-    public uint FaceCount
-    {
-        get => _faceCount;
-        private set
-        {
-            if (_faceCount != value)
-            {
-                _faceCount = value;
-                this.RaisePropertyChanged();
-                this.RaisePropertyChanged(nameof(FaceMax));
-            }
-        }
-    }
-    public uint FaceMax { get { return FaceCount - 1; } }
-
-    private uint _mipmapCount;
-    public uint MipmapCount
-    {
-        get => _mipmapCount;
-        private set
-        {
-            if (_mipmapCount != value)
-            {
-                _mipmapCount = value;
-                this.RaisePropertyChanged();
-                this.RaisePropertyChanged(nameof(MipmapMax));
-            }
-        }
-    }
-    public uint MipmapMax { get { return MipmapCount - 1; } }
-
-    public VTFImageFlag _flags;
-    public VTFImageFlag Flags
-    {
-        get => _flags;
-        private set => this.RaiseAndSetIfChanged(ref _flags, value);
-    }
-
-    private uint imageIndex = 0;
-    protected bool Opened { get; private set; }
     public override void Open()
     {
-        VTFAPI.Initialize();
-        //can't get length for byte array from LzmaStream 
-        //so we need to read to a different stream first
-        using var mem = new MemoryStream();
-        _entry.DataStream.CopyTo(mem);
-        byte[] vtfBuffer = mem.ToArray();
+        _vtfData = new VtfFileData(_entry);
 
-        if (!Opened)
-            VTFFile.CreateImage(ref imageIndex);
-        else
-            Opened = true;
-        VTFFile.BindImage(imageIndex);
-        VTFFile.ImageLoadLump(vtfBuffer, (uint)vtfBuffer.Length, false);
+        this.RaisePropertyChanged(nameof(FrameMax));
+        this.RaisePropertyChanged(nameof(FaceMax));
+        this.RaisePropertyChanged(nameof(MipmapMax));
 
-        Depth = VTFFile.ImageGetDepth();
+        Info = $"MajorVersion: {_vtfData.MajorVersion}\n" +
+               $"MinorVersion: {_vtfData.MinorVersion}\n" +
+               $"Size: {_vtfData.ImageSize}\n" +
+               $"Width: {_vtfData.ImageWidth}\n" +
+               $"Height: {_vtfData.ImageHeight}\n" +
+               $"Format: {Enum.GetName(_vtfData.ImageFormat)}\n" +
+               $"Depth: {_vtfData.Depth}\n" +
+               $"FrameCount: {_vtfData.FrameCount}\n" +
+               $"FaceCount: {_vtfData.FaceCount}\n" +
+               $"MipmapCount: {_vtfData.MipmapCount}\n" +
+               $"Flags: {_vtfData.Flags.ToString().Replace(",", "\n")}\n";
 
-        FrameCount = VTFFile.ImageGetFrameCount();
-        FaceCount = VTFFile.ImageGetFaceCount();
-        MipmapCount = VTFFile.ImageGetMipmapCount();
-        Flags = (VTFImageFlag)VTFFile.ImageGetFlags();
-
-        Info = $"MajorVersion: {VTFFile.ImageGetMajorVersion()}\n" +
-                  $"MinorVersion: {VTFFile.ImageGetMinorVersion()}\n" +
-                  $"Size: {VTFFile.ImageGetSize()}\n" +
-                  $"Width: {VTFFile.ImageGetWidth()}\n" +
-                  $"Height: {VTFFile.ImageGetHeight()}\n" +
-                  $"Format: {Enum.GetName(VTFFile.ImageGetFormat())}\n" +
-                  $"Depth: {Depth}\n" +
-                  $"FrameCount: {FrameCount}\n" +
-                  $"FaceCount: {FaceCount}\n" +
-                  $"MipmapCount: {MipmapCount}\n" +
-                  $"Flags: {Flags.ToString().Replace(",", "\n")}\n";
-
-        OpenImage();
+        UpdateImage();
     }
 
-    private void OpenImage()
+    private void UpdateImage()
     {
-        VTFFile.BindImage(imageIndex);
-        uint hasImage = VTFFile.ImageGetHasImage();
-        if (hasImage != 0)
-        {
-            uint w = VTFFile.ImageGetWidth();
-            uint h = VTFFile.ImageGetHeight();
-            var f = VTFFile.ImageGetFormat();
-            IntPtr ucharPtr = VTFFile.ImageGetData(Frame, Face, Slice, MipmapLevel);
-            var size = (int)VTFFile.ImageComputeImageSize(w, h, 1, 1, f);
-            var img = GetImage(ucharPtr, size, w, h, f);
-            Image = img;
-        }
-    }
-    private Image<Rgba32> GetImage(IntPtr ptr, int size, uint width, uint height, VTFImageFormat format)
-    {
-        var data = new byte[size];
-        Marshal.Copy(ptr, data, 0, size);
-        return GetImage(data, width, height, format);
-    }
-    private Image<Rgba32> GetImage(byte[] source, uint width, uint height, VTFImageFormat format)
-    {
-        int size = (int)width * (int)height * 4;
-        if (size <= 0)
-            throw new ArgumentException("image data array size is 0");
-        var dest = new byte[size];
-        VTFFile.ImageConvertToRGBA8888(source, dest, width, height, format);
-        var img = GetImageFromRgba8888(dest, (int)width, (int)height);
-        return img;
+        Image = _vtfData?.GetImage(Frame, Face, Slice, MipmapLevel);
     }
 
     public static Image<Rgba32> ImageFromFileStream(Stream fileSteam)
@@ -224,99 +132,26 @@ public class PakFileEntryVtfViewModel : PakFileEntryLeafViewModel
 
     public void SetImageData(Image<Rgba32> image)
     {
-        _isModified = true;
-        VTFFile.BindImage(imageIndex);
-        byte[] buffer = GetRgba888FromImage(image, out _);
+        if (_vtfData == null)
+        {
+            return;
+        }
 
-        var f = VTFFile.ImageGetFormat();
-        int size = (int)VTFFile.ImageComputeImageSize(
-            (uint)image.Width, (uint)image.Height, 1, 1, f);
-        var buffer2 = new byte[size];
-        VTFFile.ImageConvertFromRGBA8888(
-            buffer,
-            buffer2,
-            (uint)image.Width,
-            (uint)image.Height,
-            f
-            );
-        VTFFile.ImageSetData(Frame, Face, Slice, MipmapLevel, buffer2);
-        SaveVTF();
+        _isModified = true;
+        _vtfData.SetImageData(image, Frame, Face, Slice, MipmapLevel);
+        UpdateImage();
     }
 
     public void SetNewImage(Image<Rgba32> image)
     {
+        if (_vtfData == null)
+        {
+            return;
+        }
+
         _isModified = true;
-        byte[] buffer = GetRgba888FromImage(image, out bool hasAlpha);
-        var createOptions = new SVTFCreateOptions();
-        VTFFile.BindImage(imageIndex);
-        VTFFile.ImageCreateDefaultCreateStructure(ref createOptions);
-        createOptions.imageFormat = hasAlpha ?
-                                    VTFImageFormat.IMAGE_FORMAT_DXT5 :
-                                    VTFImageFormat.IMAGE_FORMAT_DXT1;
-        if (!VTFFile.ImageCreateSingle(
-            (uint)image.Width,
-            (uint)image.Height,
-            buffer,
-            ref createOptions))
-        {
-            string err = VTFAPI.GetLastError();
-            Console.WriteLine(err);
-        }
-
-        SaveVTF();
-    }
-
-    public void SaveVTF()
-    {
-        var vtfBuffer = new byte[VTFFile.ImageGetSize()];
-        _entry.DataStream = new MemoryStream(vtfBuffer);
-
-        uint uiSize = 0;
-        if (!VTFFile.ImageSaveLump(vtfBuffer, (uint)vtfBuffer.Length, ref uiSize))
-        {
-            string err = VTFAPI.GetLastError();
-            Console.WriteLine(err);
-        }
-        _entry.DataStream.Seek(0, SeekOrigin.Begin);
-    }
-
-    private static Image<Rgba32> GetImageFromRgba8888(byte[] img, int width, int height)
-    {
-        var rgba = new Rgba32[width * height];
-        int j = 0;
-        for (int i = 0; i < img.Length; i += 4)
-        {
-            rgba[j++] = new Rgba32(
-                img[i],
-                img[i + 1],
-                img[i + 2],
-                img[i + 3]);
-        }
-
-        return SixLabors.ImageSharp.Image.LoadPixelData<Rgba32>(rgba.AsSpan(), width, height);
-    }
-
-    private static byte[] GetRgba888FromImage(Image<Rgba32> image, out bool hasAlpha)
-    {
-        int size = image.Width * image.Height * 4;
-        using var mem = new MemoryStream();
-        var buffer = new byte[size];
-        int i = 0;
-        hasAlpha = false;
-        for (int y = 0; y < image.Height; y++)
-        {
-            for (int x = 0; x < image.Width; x++)
-            {
-                Rgba32 pixel = image[x, y];
-                buffer[i++] = pixel.R;
-                buffer[i++] = pixel.G;
-                buffer[i++] = pixel.B;
-                buffer[i++] = pixel.A;
-                if (!hasAlpha && pixel.A != 255)
-                    hasAlpha = true;
-            }
-        }
-        return buffer;
+        _vtfData.SetNewImage(image);
+        UpdateImage();
     }
 
     public override void Update()

--- a/src/Lumper.UI/ViewModels/MainWindowViewModel.IO.cs
+++ b/src/Lumper.UI/ViewModels/MainWindowViewModel.IO.cs
@@ -8,7 +8,9 @@ using System.Threading.Tasks;
 using Avalonia.Platform.Storage;
 using Lumper.Lib.BSP;
 using Lumper.Lib.BSP.IO;
+using Lumper.Lib.BSP.Lumps.BspLumps;
 using Lumper.UI.ViewModels.Bsp;
+using Lumper.UI.ViewModels.VtfBrowser;
 using MessageBox.Avalonia;
 using MessageBox.Avalonia.Enums;
 using ReactiveUI;
@@ -153,6 +155,7 @@ public partial class MainWindowViewModel
         var bspFile = new BspFile(path);
         BspModel = new BspViewModel(bspFile);
         TasksModel = new Tasks.TasksViewModel(bspFile);
+        VtfBrowserModel = new VtfBrowserViewModel(bspFile.GetLump<PakFileLump>());
         Content = BspModel;
     }
 

--- a/src/Lumper.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Lumper.UI/ViewModels/MainWindowViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Lumper.UI.ViewModels.Bsp;
 using Lumper.UI.ViewModels.Tasks;
+using Lumper.UI.ViewModels.VtfBrowser;
 using ReactiveUI;
 
 namespace Lumper.UI.ViewModels;
@@ -16,6 +17,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private BspNodeBase? _selectedNode;
     private BspViewModel? _bspModel;
     private TasksViewModel? _tasksModel;
+    private VtfBrowserViewModel? _vtfBrowserModel;
 
     public MainWindowViewModel()
     {
@@ -67,6 +69,12 @@ public partial class MainWindowViewModel : ViewModelBase
         set => this.RaiseAndSetIfChanged(ref _tasksModel, value);
     }
 
+    public VtfBrowserViewModel? VtfBrowserModel
+    {
+        get => _vtfBrowserModel;
+        set => this.RaiseAndSetIfChanged(ref _vtfBrowserModel, value);
+    }
+
     public void ViewBsp()
     {
         Content = BspModel;
@@ -75,5 +83,10 @@ public partial class MainWindowViewModel : ViewModelBase
     public void ViewTasks()
     {
         Content = TasksModel;
+    }
+
+    public void ViewTextureBrowser()
+    {
+        Content = VtfBrowserModel;
     }
 }

--- a/src/Lumper.UI/ViewModels/VtfBrowser/VtfBrowserItemViewModel.cs
+++ b/src/Lumper.UI/ViewModels/VtfBrowser/VtfBrowserItemViewModel.cs
@@ -1,0 +1,60 @@
+using ReactiveUI;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using Lumper.UI.Models;
+using Lumper.Lib.VTF;
+using System.Linq;
+
+namespace Lumper.UI.ViewModels.VtfBrowser;
+
+public class VtfBrowserItemViewModel : ViewModelBase
+{
+    public VtfBrowserItemViewModel(string key, VtfFileData vtfFileData)
+    {
+        Path = key;
+        Name = key.Split('/').Last();
+        _vtfFileData = vtfFileData;
+    }
+
+    private readonly VtfFileData _vtfFileData;
+
+    private bool _isVisible = true;
+
+    public bool IsVisible
+    {
+        get => _isVisible;
+        set => this.RaiseAndSetIfChanged(ref _isVisible, value);
+    }
+
+
+    private string _name = "";
+
+    public string Name
+    {
+        get => _name;
+        set => this.RaiseAndSetIfChanged(ref _name, value);
+    }
+
+    private string _path = "";
+
+    public string Path
+    {
+        get => _path;
+        set => this.RaiseAndSetIfChanged(ref _path, value);
+    }
+
+    private Image<Rgba32>? _image = null;
+
+    public Image<Rgba32>? Image
+    {
+        get
+        {
+            if (_image is null)
+            {
+                _image = _vtfFileData.GetImage(0, 0, 0, 0);
+            }
+            return _image;
+        }
+        set => this.RaiseAndSetIfChanged(ref _image, value);
+    }
+}

--- a/src/Lumper.UI/ViewModels/VtfBrowser/VtfBrowserViewModel.cs
+++ b/src/Lumper.UI/ViewModels/VtfBrowser/VtfBrowserViewModel.cs
@@ -1,0 +1,109 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Lumper.Lib.BSP.Lumps.BspLumps;
+using Lumper.UI.Models;
+using Lumper.UI.Models.Matchers;
+using ReactiveUI;
+
+namespace Lumper.UI.ViewModels.VtfBrowser;
+
+public partial class VtfBrowserViewModel : ViewModelBase
+{
+    public VtfBrowserViewModel(PakFileLump pakFileLump)
+    {
+        var entries = pakFileLump.Entries.Where(
+            x => x.Key.ToLower().EndsWith(".vtf"));
+        foreach (var entry in entries)
+        {
+            _textureBrowserItems.Add(new VtfBrowserItemViewModel(
+            entry.Key, new VtfFileData(entry)));
+        }
+
+        UpdateItems();
+    }
+
+    private double _dimensions = 128;
+
+    public double Dimensions
+    {
+        get => _dimensions;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _dimensions, value);
+            this.RaisePropertyChanged(nameof(MaxNameWidth));
+        }
+    }
+
+    // 8 is how much the text will be offset from the sides, so 4px left and 4px right
+    public uint MaxNameWidth => (uint)_dimensions - 8;
+
+    private bool _showCubemaps = true;
+
+    public bool ShowCubemaps
+    {
+        get => _showCubemaps;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _showCubemaps, value);
+            UpdateItems();
+        }
+    }
+
+    private string _textureSearch = "";
+
+    public string TextureSearch
+    {
+        get => _textureSearch;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _textureSearch, value);
+            UpdateItems();
+        }
+    }
+
+    private string _texturesCount = "";
+
+    public string TexturesCount
+    {
+        get => _texturesCount;
+        set => this.RaiseAndSetIfChanged(ref _texturesCount, value);
+    }
+
+    // matches cubemap names which are formatted as cX_cY_cZ.vtf or cubemapdefault.vtf, including .hdr.vtf versions
+    // X Y Z are the cubemap's origin
+    // https://github.com/ValveSoftware/source-sdk-2013/blob/master/mp/src/utils/vbsp/cubemap.cpp
+    [GeneratedRegex(@"^((c-?\d+_-?\d+_-?\d+)|cubemapdefault)(\.hdr){0,}\.vtf$")]
+    private static partial Regex _rgxCubemap();
+
+    private ObservableCollection<VtfBrowserItemViewModel> _textureBrowserItems =
+        new();
+
+    public ObservableCollection<VtfBrowserItemViewModel> TextureBrowserItems => _textureBrowserItems;
+
+    private void UpdateItems()
+    {
+        bool isGlobPattern = TextureSearch.Contains('*') || TextureSearch.Contains('?');
+        var matcher = isGlobPattern
+            ? new GlobMatcher(TextureSearch, false, true)
+            : new GlobMatcher($"*{TextureSearch}*", false, true);
+
+        int count = 0;
+
+        foreach (var item in TextureBrowserItems)
+        {
+            if (!_showCubemaps && _rgxCubemap().IsMatch(item.Name))
+            {
+                item.IsVisible = false;
+                continue;
+            }
+
+            item.IsVisible =  string.IsNullOrWhiteSpace(TextureSearch)
+                   || matcher.Match(item.Name).Result;
+
+            if (item.IsVisible) count++;
+        }
+
+        TexturesCount = $"{count} Items";
+    }
+}

--- a/src/Lumper.UI/Views/Bsp/Lumps/PakFile/PakFileEntryVtfView.axaml.cs
+++ b/src/Lumper.UI/Views/Bsp/Lumps/PakFile/PakFileEntryVtfView.axaml.cs
@@ -68,8 +68,6 @@ public partial class PakFileEntryVtfView : UserControl
                 vm.SetNewImage(img);
             else
                 vm.SetImageData(img);
-            //open so we can check everything worked
-            vm.Open();
         }
     }
     private static IReadOnlyList<FilePickerFileType> GenerateImageFileFilter()

--- a/src/Lumper.UI/Views/Bsp/Lumps/PakFile/PakFileLumpView.axaml.cs
+++ b/src/Lumper.UI/Views/Bsp/Lumps/PakFile/PakFileLumpView.axaml.cs
@@ -37,7 +37,7 @@ public partial class PakFileLumpView : UserControl
 
     private async ValueTask<string?> PickFolder(string title)
     {
-        string path = null;
+        string? path = null;
         if (Desktop.MainWindow is null)
             return path;
         var dialog = new FolderPickerOpenOptions()

--- a/src/Lumper.UI/Views/MainWindow.axaml
+++ b/src/Lumper.UI/Views/MainWindow.axaml
@@ -3,8 +3,6 @@
         xmlns:vm="using:Lumper.UI.ViewModels"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:bspviews="clr-namespace:Lumper.UI.Views.Bsp"
-        xmlns:taskviews="clr-namespace:Lumper.UI.Views.Tasks"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="Lumper.UI.Views.MainWindow"
         Icon="/Assets/Lumper.png"
@@ -46,6 +44,7 @@
                     <MenuItem Header="_View">
                         <MenuItem Header="_Browser" Command="{Binding ViewBsp}" />
                         <MenuItem Header="_Tasks" Command="{Binding ViewTasks}" />
+                        <MenuItem Header="_Texture Browser" Command="{Binding ViewTextureBrowser}" />
                     </MenuItem>
                 </Menu>
             </DockPanel>

--- a/src/Lumper.UI/Views/VtfBrowser/VtfBrowserView.axaml
+++ b/src/Lumper.UI/Views/VtfBrowser/VtfBrowserView.axaml
@@ -1,0 +1,73 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:converters="clr-namespace:Lumper.UI.Converters"
+             xmlns:vm="clr-namespace:Lumper.UI.ViewModels.VtfBrowser"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Lumper.UI.Views.VtfBrowser.VtfBrowserView">
+
+    <UserControl.Resources>
+        <converters:BitmapAssetValueConverter x:Key="variableImage" />
+    </UserControl.Resources>
+
+    <Grid RowDefinitions="*, Auto">
+        <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
+            <ItemsControl HorizontalAlignment="Center" Items="{Binding TextureBrowserItems}">
+
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border BorderBrush="Silver" BorderThickness="1" Margin="5"
+                                CornerRadius="5" DoubleTapped="Item_DoubleTapped" IsVisible="{Binding IsVisible}">
+                            <ContentPresenter Content="{Binding}">
+                                <ContentPresenter.ContentTemplate>
+                                    <DataTemplate>
+                                        <StackPanel>
+                                            <Image
+                                                Height="{Binding DataContext.Dimensions, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                Width="{Binding DataContext.Dimensions, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                Source="{Binding Image, Converter={StaticResource variableImage}}"/>
+                                            <TextBlock
+                                                MaxWidth="{Binding DataContext.MaxNameWidth, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                TextTrimming="CharacterEllipsis"
+                                                HorizontalAlignment="Center"
+                                                Text="{Binding Name}" />
+                                            <ToolTip.Tip>
+                                                <TextBlock Text="{Binding Path}"/>
+                                            </ToolTip.Tip>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ContentPresenter.ContentTemplate>
+                            </ContentPresenter>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+
+            </ItemsControl>
+        </ScrollViewer>
+
+        <Border Grid.Row="1" BorderBrush="Silver" Margin="5 5 5 0" BorderThickness="0 1 0 0 ">
+            <Grid Grid.Row="1" Height="64" ColumnDefinitions="128, 120, 6, *, *">
+                <TextBox HorizontalAlignment="Center" Height="32" Width="128" Margin="5"
+                         Text="{Binding TextureSearch}" Watermark="Search"/>
+                <CheckBox Grid.Column="1" Margin="5" VerticalAlignment="Center"
+                          HorizontalAlignment="Stretch" IsChecked="{Binding ShowCubemaps, Mode=TwoWay}">Cubemaps</CheckBox>
+
+                <Border Grid.Column="2" Height="32" Width="1" Margin="0 0 20 0 " BorderBrush="Silver" BorderThickness="0 0  5 0" />
+
+                <TextBlock Grid.Column="3" VerticalAlignment="Center" HorizontalAlignment="Left"
+                           Text="{Binding TexturesCount}" />
+                <Slider Grid.Column="4" Width="200" Margin="0 5 20 5" HorizontalAlignment="Right"
+                        Minimum="128" Maximum="512"
+                        Value="{Binding Dimensions, Mode=TwoWay}" />
+            </Grid>
+        </Border>
+    </Grid>
+
+</UserControl>

--- a/src/Lumper.UI/Views/VtfBrowser/VtfBrowserView.axaml.cs
+++ b/src/Lumper.UI/Views/VtfBrowser/VtfBrowserView.axaml.cs
@@ -1,0 +1,28 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Lumper.UI.ViewModels.VtfBrowser;
+
+namespace Lumper.UI.Views.VtfBrowser;
+
+public partial class VtfBrowserView : UserControl
+{
+    public VtfBrowserView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    private void Item_DoubleTapped(object? sender, TappedEventArgs e)
+    {
+        var selectedVtf = (VtfBrowserItemViewModel)((Border)sender!).DataContext!;
+
+        var window = new VtfImageWindow();
+        window.DataContext = selectedVtf;
+        window.Show();
+    }
+}

--- a/src/Lumper.UI/Views/VtfBrowser/VtfImageWindow.axaml
+++ b/src/Lumper.UI/Views/VtfBrowser/VtfImageWindow.axaml
@@ -1,0 +1,17 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:Lumper.UI.ViewModels.VtfBrowser"
+        xmlns:converters="clr-namespace:Lumper.UI.Converters"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        x:Class="Lumper.UI.Views.VtfBrowser.VtfImageWindow"
+        Title="{Binding Path}">
+
+    <Window.Resources>
+        <converters:BitmapAssetValueConverter x:Key="variableImage" />
+    </Window.Resources>
+
+    <Image Source="{Binding Image, Converter={StaticResource variableImage}}" />
+
+</Window>

--- a/src/Lumper.UI/Views/VtfBrowser/VtfImageWindow.axaml.cs
+++ b/src/Lumper.UI/Views/VtfBrowser/VtfImageWindow.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Lumper.UI.Views.VtfBrowser;
+
+public partial class VtfImageWindow : Window
+{
+    public VtfImageWindow()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
![resim](https://github.com/momentum-mod/lumper/assets/45337750/5e93ded7-2a50-4879-bcaf-4067d0af785e)

One issue with this is that it is a bit laggy if you scroll too fast and there's a lot of images. Avalonia doesn't have any virtualization for WrapPanel but we could implement [this](https://github.com/AvaloniaUI/Avalonia/pull/11251). They haven't merged it because of it's insufficient support for elements of different sizes but that's not an issue for us.

Also I've added the truncation because it's very ugly if we show really long names. You can see the full name when you hover over.