### PR TITLE
Logging via ILogger instead of Console and showing logs in UI

### DIFF
--- a/src/Lumper.UI/App.axaml.cs
+++ b/src/Lumper.UI/App.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Lumper.UI.ViewModels;
 using Lumper.UI.Views;
+using Microsoft.Extensions.Logging;
 
 namespace Lumper.UI;
 
@@ -23,5 +24,7 @@ public class App : Application
             };
 
         base.OnFrameworkInitializationCompleted();
+
+        LumperLoggerFactory.GetInstance().CreateLogger(GetType()).LogInformation("Application Initialized");
     }
 }

--- a/src/Lumper.UI/Lumper.UI.csproj
+++ b/src/Lumper.UI/Lumper.UI.csproj
@@ -63,4 +63,7 @@
             <TargetPath>VTFLib.NET.dll</TargetPath>
         </None>
     </ItemGroup>
+    <ItemGroup>
+      <UpToDateCheckInput Remove="Views\Logs\LogsView.axaml" />
+    </ItemGroup>
 </Project>

--- a/src/Lumper.UI/Models/Vtf/VtfFileData.cs
+++ b/src/Lumper.UI/Models/Vtf/VtfFileData.cs
@@ -5,6 +5,7 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using VTFLib;
 using Lumper.Lib.BSP.Struct;
+using Microsoft.Extensions.Logging;
 
 namespace Lumper.UI.Models;
 
@@ -126,7 +127,9 @@ public class VtfFileData
                 ref createOptions))
         {
             string err = VTFAPI.GetLastError();
-            Console.WriteLine(err);
+
+            var logger = LumperLoggerFactory.GetInstance().CreateLogger(GetType());
+            logger.LogError(err);
         }
 
         SaveVtf();
@@ -143,7 +146,9 @@ public class VtfFileData
         if (!VTFFile.ImageSaveLump(vtfBuffer, (uint)vtfBuffer.Length, ref uiSize))
         {
             string err = VTFAPI.GetLastError();
-            Console.WriteLine(err);
+
+            var logger = LumperLoggerFactory.GetInstance().CreateLogger(GetType());
+            logger.LogError(err);
         }
 
         _entry.DataStream.Seek(0, SeekOrigin.Begin);

--- a/src/Lumper.UI/Program.cs
+++ b/src/Lumper.UI/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Avalonia;
 using Avalonia.ReactiveUI;
 

--- a/src/Lumper.UI/ViewModels/Bsp/BspNodeBase.cs
+++ b/src/Lumper.UI/ViewModels/Bsp/BspNodeBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive.Linq;
@@ -102,9 +102,13 @@ public abstract class BspNodeBase : ViewModelBase
     public virtual void Open()
     { }
 
-    public void Close()
+    public async ValueTask Close()
     {
-        BspView.Close(this);
+        await new LumperCodeExecutionHelper().ExecuteAndLogError(async () =>
+        {
+            BspView.Close(this);
+        });
+
     }
 
     //hack used for the hotkey on invisible button
@@ -112,9 +116,12 @@ public abstract class BspNodeBase : ViewModelBase
     //adding and removing the hotkey in code behind didn't work
     //hotkey in mainwindow menu didn't work either
     //so this is my ugly workaround
-    public void CloseSelected()
+    public async ValueTask CloseSelected()
     {
-        BspView.Close(BspView.SelectedTab);
+        await new LumperCodeExecutionHelper().ExecuteAndLogError(async () =>
+        {
+            BspView.Close(BspView.SelectedTab);
+        });
     }
 
     public async ValueTask Reset()
@@ -193,9 +200,13 @@ public abstract class BspNodeBase : ViewModelBase
         return result;
     }
 
-    public void ExpandTree()
+    public async ValueTask ExpandTree()
     {
-        ExpandTree(_ => true);
+        await new LumperCodeExecutionHelper().ExecuteAndLogError(async () =>
+        {
+            ExpandTree(_ => true);
+        });
+        
     }
     public void ExpandTree(Func<BspNodeBase, bool> fun)
     {

--- a/src/Lumper.UI/ViewModels/Bsp/Lumps/PakFile/PakFileLumpViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Bsp/Lumps/PakFile/PakFileLumpViewModel.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Collections.Generic;
 using SharpCompress.Archives.Zip;
 using Lumper.Lib.BSP.Lumps.BspLumps;
+using Microsoft.Extensions.Logging;
 
 namespace Lumper.UI.ViewModels.Bsp.Lumps.PakFile;
 
@@ -79,7 +80,7 @@ public class PakFileLumpViewModel : LumpBase
         if (exportDir.GetFiles().Any()
             || exportDir.GetDirectories().Any())
         {
-            Console.WriteLine("Refusing to export to a directory containing stuff");
+            _logger.LogError("Refusing to export to a directory containing stuff");
             //todo messagebox .. but not here because of dependencies?
             //option to delete files?
             return;
@@ -94,7 +95,7 @@ public class PakFileLumpViewModel : LumpBase
         }
         catch (Exception ex)
         {
-            Console.WriteLine("Failed to extract zip: " + ex.Message);
+            _logger.LogError("Failed to extract zip: " + ex.Message);
             return;
         }
         while (reader.MoveToNextEntry())

--- a/src/Lumper.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Lumper.UI/ViewModels/MainWindowViewModel.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Lumper.UI.ViewModels.Bsp;
+using Lumper.UI.ViewModels.Logs;
 using Lumper.UI.ViewModels.Tasks;
 using Lumper.UI.ViewModels.VtfBrowser;
 using ReactiveUI;
@@ -18,6 +19,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private BspViewModel? _bspModel;
     private TasksViewModel? _tasksModel;
     private VtfBrowserViewModel? _vtfBrowserModel;
+    private LogsViewModel? _logsModel;
 
     public MainWindowViewModel()
     {
@@ -29,8 +31,12 @@ public partial class MainWindowViewModel : ViewModelBase
 
         Desktop = desktop;
 
+        _logsModel = new LogsViewModel();
+
         IOInit();
-        Content = BspModel;
+
+        // Show Logs as initial view
+        Content = LogsModel;
     }
 
     private void OnLoad()
@@ -75,6 +81,12 @@ public partial class MainWindowViewModel : ViewModelBase
         set => this.RaiseAndSetIfChanged(ref _vtfBrowserModel, value);
     }
 
+    public LogsViewModel? LogsModel
+    {
+        get => _logsModel;
+        set => this.RaiseAndSetIfChanged(ref _logsModel, value);
+    }
+
     public void ViewBsp()
     {
         Content = BspModel;
@@ -88,5 +100,10 @@ public partial class MainWindowViewModel : ViewModelBase
     public void ViewTextureBrowser()
     {
         Content = VtfBrowserModel;
+    }
+
+    public void ViewLogs()
+    {
+        Content = LogsModel;
     }
 }

--- a/src/Lumper.UI/ViewModels/Tasks/ChangeTextureTaskViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Tasks/ChangeTextureTaskViewModel.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using Lumper.Lib.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Lumper.UI.ViewModels.Tasks;
 
@@ -21,7 +22,7 @@ public partial class ChangeTextureTaskViewModel : TaskViewModel
         }
         catch (Exception ex)
         {
-            Console.WriteLine(ex.Message);
+            _logger.LogError(ex.Message);
         }
     }
 

--- a/src/Lumper.UI/ViewModels/Tasks/TasksViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Tasks/TasksViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
@@ -11,6 +11,7 @@ using ReactiveUI;
 using Newtonsoft.Json;
 using Lumper.Lib.Tasks;
 using Lumper.Lib.BSP;
+using Microsoft.Extensions.Logging;
 
 namespace Lumper.UI.ViewModels.Tasks;
 
@@ -133,7 +134,7 @@ public partial class TasksViewModel : ViewModelBase
             }
             catch (Exception e)
             {
-                Console.WriteLine(e.Message);
+                _logger.LogError(e.Message);
             }
             IsRunning = false;
         });

--- a/src/Lumper.UI/ViewModels/ViewModelBase.cs
+++ b/src/Lumper.UI/ViewModels/ViewModelBase.cs
@@ -1,4 +1,5 @@
-﻿using ReactiveUI;
+using Microsoft.Extensions.Logging;
+using ReactiveUI;
 
 namespace Lumper.UI.ViewModels;
 
@@ -7,4 +8,10 @@ namespace Lumper.UI.ViewModels;
 /// </summary>
 public class ViewModelBase : ReactiveObject
 {
+    protected ILogger _logger;
+
+    public ViewModelBase()
+    {
+        _logger = LumperLoggerFactory.GetInstance().CreateLogger(GetType());
+    }
 }

--- a/src/Lumper.UI/Views/MainWindow.axaml
+++ b/src/Lumper.UI/Views/MainWindow.axaml
@@ -13,6 +13,23 @@
         WindowStartupLocation="CenterScreen"
         Background="Transparent">
 
+    <Window.Styles>
+        <Style Selector="TextBlock.gray">
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="Foreground" Value="#888888"/>
+        </Style>
+
+        <Style Selector="TextBlock.yellow">
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="Foreground" Value="#FFFF00"/>
+        </Style>
+
+        <Style Selector="TextBlock.red">
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="Foreground" Value="#FF0000"/>
+        </Style>
+    </Window.Styles>
+
     <Design.DataContext>
         <vm:MainWindowViewModel />
     </Design.DataContext>
@@ -45,6 +62,7 @@
                         <MenuItem Header="_Browser" Command="{Binding ViewBsp}" />
                         <MenuItem Header="_Tasks" Command="{Binding ViewTasks}" />
                         <MenuItem Header="_Texture Browser" Command="{Binding ViewTextureBrowser}" />
+                        <MenuItem Header="_Logs" Command="{Binding ViewLogs}" />
                     </MenuItem>
                 </Menu>
             </DockPanel>

--- a/src/Lumper.UI/Views/Tasks/TasksView.axaml.cs
+++ b/src/Lumper.UI/Views/Tasks/TasksView.axaml.cs
@@ -47,30 +47,36 @@ public partial class TasksView : UserControl
 
     public async void OnLoadClick(object sender, RoutedEventArgs e)
     {
-        if (Desktop.MainWindow is null)
-            return;
+        await new LumperCodeExecutionHelper().ExecuteAndLogError(async () =>
+        {
+            if (Desktop.MainWindow is null)
+                return;
 
-        var dialog = new FilePickerOpenOptions();
-        dialog.AllowMultiple = false;
-        dialog.Title = "Pick tasks file";
-        dialog.FileTypeFilter = GenerateJsonFileFilter();
-        var result = await Desktop.MainWindow.StorageProvider.OpenFilePickerAsync(dialog);
-        if (result is not { Count: 1 })
-            return;
-        if (DataContext is TasksViewModel vm)
-            vm.Load(await result[0].OpenReadAsync());
+            var dialog = new FilePickerOpenOptions();
+            dialog.AllowMultiple = false;
+            dialog.Title = "Pick tasks file";
+            dialog.FileTypeFilter = GenerateJsonFileFilter();
+            var result = await Desktop.MainWindow.StorageProvider.OpenFilePickerAsync(dialog);
+            if (result is not { Count: 1 })
+                return;
+            if (DataContext is TasksViewModel vm)
+                vm.Load(await result[0].OpenReadAsync());
+        });
     }
     public async void OnSaveClick(object sender, RoutedEventArgs e)
     {
-        if (Desktop.MainWindow is null)
-            return;
-        var dialog = new FilePickerSaveOptions();
-        dialog.Title = "Pick tasks file";
-        dialog.FileTypeChoices = GenerateJsonFileFilter();
-        var result = await Desktop.MainWindow.StorageProvider.SaveFilePickerAsync(dialog);
-        if (result is null)
-            return;
-        if (DataContext is TasksViewModel vm)
-            vm.Save(await result.OpenWriteAsync());
+        await new LumperCodeExecutionHelper().ExecuteAndLogError(async () =>
+        {
+            if (Desktop.MainWindow is null)
+                return;
+            var dialog = new FilePickerSaveOptions();
+            dialog.Title = "Pick tasks file";
+            dialog.FileTypeChoices = GenerateJsonFileFilter();
+            var result = await Desktop.MainWindow.StorageProvider.SaveFilePickerAsync(dialog);
+            if (result is null)
+                return;
+            if (DataContext is TasksViewModel vm)
+                vm.Save(await result.OpenWriteAsync());
+        });        
     }
 }

--- a/src/Lumper/BSP/BspFile.cs
+++ b/src/Lumper/BSP/BspFile.cs
@@ -6,6 +6,7 @@ using Lumper.Lib.BSP.Lumps;
 using Lumper.Lib.BSP.Lumps.BspLumps;
 using Lumper.Lib.BSP.IO;
 using Newtonsoft.Json;
+using Microsoft.Extensions.Logging;
 
 namespace Lumper.Lib.BSP
 {
@@ -109,7 +110,8 @@ namespace Lumper.Lib.BSP
                 FileAccess.Write);
 
             ToJson(fileStream, sortLumps, sortProperties, ignoreOffset);
-            Console.WriteLine("JSON file: " + path);
+            var logger = LumperLoggerFactory.GetInstance().CreateLogger<BspFile>();
+            logger.LogInformation("JSON file: " + path);
         }
 
         public void ToJson(Stream stream,

--- a/src/Lumper/BSP/IO/BspFileReader.cs
+++ b/src/Lumper/BSP/IO/BspFileReader.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Lumper.Lib.BSP.Lumps;
 using Lumper.Lib.BSP.Lumps.BspLumps;
 using Newtonsoft.Json;
+using Microsoft.Extensions.Logging;
 
 namespace Lumper.Lib.BSP.IO
 {
@@ -50,7 +51,7 @@ namespace Lumper.Lib.BSP.IO
                 throw new InvalidDataException("File doesn't look like a VBSP");
 
             _bsp.Version = ReadInt32();
-            Console.WriteLine($"BSP version: {_bsp.Version}");
+            _logger.LogInformation($"BSP version: {_bsp.Version}");
 
             for (var i = 0; i < BspFile.HeaderLumps; i++)
             {
@@ -85,7 +86,7 @@ namespace Lumper.Lib.BSP.IO
                     lumpHeader.UncompressedLength = fourCc;
                 }
 
-                Console.WriteLine($"Lump {type}({(int)type})"
+                _logger.LogInformation($"Lump {type}({(int)type})"
                                   + $"\toffset: {lumpHeader.Offset}"
                                   + $"\t length: {length}"
                                   + $"\t Version: {lump.Version}"
@@ -120,14 +121,14 @@ namespace Lumper.Lib.BSP.IO
                     gameLumpHeader = header;
                     if (gameLumpHeader.Length == 0 && gameLumpHeader.Offset == 0)
                     {
-                        Console.WriteLine("GameLump length and offset 0 .. won't set new length");
+                        _logger.LogInformation("GameLump length and offset 0 .. won't set new length");
                         break;
                     }
                 }
                 else if (gameLump is not null && header.Offset != 0 && header.Offset != gameLumpHeader.Offset)
                 {
                     gameLumpHeader.UncompressedLength = header.Offset - gameLumpHeader.Offset;
-                    Console.WriteLine($"Changed gamelump length to {gameLumpHeader.Length}");
+                    _logger.LogInformation($"Changed gamelump length to {gameLumpHeader.Length}");
                     break;
                 }
             }
@@ -171,15 +172,15 @@ namespace Lumper.Lib.BSP.IO
                     long prevEnd = prevHeader.Offset + prevHeader.Length;
                     if (header.Offset < prevEnd)
                     {
-                        Console.WriteLine($"Lumps {prevLump.Type} and {lump.Type} overlapping");
+                        _logger.LogInformation($"Lumps {prevLump.Type} and {lump.Type} overlapping");
                         if (prevLump.Type == BspLumpType.Game_lump)
-                            Console.WriteLine("but the previous lump was GAME_LUMP and the length is a lie");
+                            _logger.LogInformation("but the previous lump was GAME_LUMP and the length is a lie");
                         else
                             ret = true;
                     }
                     else if (header.Offset > prevEnd)
                     {
-                        Console.WriteLine($"Space between lumps {prevLump.Type} {prevEnd} <-- {header.Offset - prevEnd} --> {header.Offset} {lump.Type}");
+                        _logger.LogInformation($"Space between lumps {prevLump.Type} {prevEnd} <-- {header.Offset - prevEnd} --> {header.Offset} {lump.Type}");
                     }
 
                     if (header.Offset + header.Length >= prevEnd)
@@ -206,7 +207,7 @@ namespace Lumper.Lib.BSP.IO
                 if (end < 0)
                 {
                     end = texDataStringDataLump.Data.Length;
-                    Console.WriteLine("WARING: didn't find null at the end of texture string");
+                    _logger.LogWarning("WARNING: didn't find null at the end of texture string");
                 }
                 texture.TexName = end > 0
                     ? TexDataStringDataLump.TextureNameEncoding.GetString(

--- a/src/Lumper/BSP/IO/BspFileWriter.cs
+++ b/src/Lumper/BSP/IO/BspFileWriter.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
 using Lumper.Lib.BSP.Lumps.BspLumps;
+using Microsoft.Extensions.Logging;
 
 namespace Lumper.Lib.BSP.IO
 {
@@ -67,13 +68,13 @@ namespace Lumper.Lib.BSP.IO
 
                 if ((lump is GameLump || lump is PakFileLump) && lump.Compress)
                 {
-                    Console.WriteLine($"Let's not compress {lump.GetType().Name} .. it's a silly place");
+                    _logger.LogInformation($"Let's not compress {lump.GetType().Name} .. it's a silly place");
                     lump.Compress = false;
                 }
                 LumpHeader newHeader = Write(lump);
                 LumpHeaders[lumpType] = new BspLumpHeader(newHeader, lump.Version);
 
-                Console.WriteLine($"Lump {lumpType}({(int)lumpType})\n\t{newHeader.Offset}\n\t{newHeader.Length}");
+                _logger.LogInformation($"Lump {lumpType}({(int)lumpType})\n\t{newHeader.Offset}\n\t{newHeader.Length}");
             }
         }
         private void ConstructTexDataLumps()

--- a/src/Lumper/BSP/IO/GameLumpReader.cs
+++ b/src/Lumper/BSP/IO/GameLumpReader.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 using Lumper.Lib.BSP.Lumps;
 using Lumper.Lib.BSP.Lumps.BspLumps;
 using Lumper.Lib.BSP.Lumps.GameLumps;
+using Microsoft.Extensions.Logging;
 
 namespace Lumper.Lib.BSP.IO
 {
@@ -83,15 +84,15 @@ namespace Lumper.Lib.BSP.IO
                 Lumps.Add(new Tuple<Lump, LumpHeader>(lump, header));
 
                 if (_gameLump.Lumps.ContainsKey(type))
-                    Console.WriteLine($"WARNING: key {type} already in gamelumps .. skipping");
+                    _logger.LogWarning($"WARNING: key {type} already in gamelumps .. skipping");
                 else
                     _gameLump.Lumps.Add(type, lump);
 
-                Console.WriteLine($"Gamelump " + _gameLump.Lumps.Count);
-                Console.WriteLine($"\tId: {type} {(int)type}");
-                Console.WriteLine($"\tFlags: {lump.Flags}");
-                Console.WriteLine($"\tFileofs: {header.Offset}");
-                Console.WriteLine($"\tFilelen: {header.UncompressedLength}");
+                _logger.LogInformation($"Gamelump " + _gameLump.Lumps.Count);
+                _logger.LogInformation($"\tId: {type} {(int)type}");
+                _logger.LogInformation($"\tFlags: {lump.Flags}");
+                _logger.LogInformation($"\tFileofs: {header.Offset}");
+                _logger.LogInformation($"\tFilelen: {header.UncompressedLength}");
 
                 prevHeader = header;
                 //lump is compressed if the last bit is 1 

--- a/src/Lumper/BSP/IO/LumpReader.cs
+++ b/src/Lumper/BSP/IO/LumpReader.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using SharpCompress.Compressors.LZMA;
 using Newtonsoft.Json;
 using Lumper.Lib.BSP.Lumps;
+using Microsoft.Extensions.Logging;
 
 namespace Lumper.Lib.BSP.IO
 {
@@ -14,11 +15,15 @@ namespace Lumper.Lib.BSP.IO
     [JsonObject(MemberSerialization.OptIn)]
     public abstract class LumpReader : BinaryReader
     {
+        protected ILogger _logger;
+
         // lumpheader information is only needed in the reader
         protected List<Tuple<Lump, LumpHeader>> Lumps = new();
 
         public LumpReader(Stream input) : base(input)
-        { }
+        {
+            _logger = LumperLoggerFactory.GetInstance().CreateLogger(GetType());
+        }
         protected abstract void ReadHeader();
         protected virtual void LoadAll()
         {
@@ -108,7 +113,7 @@ namespace Lumper.Lib.BSP.IO
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex.Message);
+                _logger.LogError(ex.Message);
             }
         }
 

--- a/src/Lumper/BSP/Lumps/BspLumps/EntityLump.cs
+++ b/src/Lumper/BSP/Lumps/BspLumps/EntityLump.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Linq;
 using System.Collections.Generic;
 using Lumper.Lib.BSP.Struct;
+using Microsoft.Extensions.Logging;
 
 namespace Lumper.Lib.BSP.Lumps.BspLumps
 {
@@ -18,6 +19,8 @@ namespace Lumper.Lib.BSP.Lumps.BspLumps
 
         private bool ReadEntity(BinaryReader reader, long endPos)
         {
+            var logger = LumperLoggerFactory.GetInstance().CreateLogger(GetType());
+
             var stringBuilder = new StringBuilder(512);
             var keyValues = new List<KeyValuePair<string, string>>();
 
@@ -78,7 +81,7 @@ namespace Lumper.Lib.BSP.Lumps.BspLumps
 
                                         if (key.Length == 0)
                                         {
-                                            Console.WriteLine(
+                                            logger.LogInformation(
                                                 "Entity parser skipped value \"{0}\" for empty key, how u do dis?", value);
                                         }
 
@@ -109,7 +112,7 @@ namespace Lumper.Lib.BSP.Lumps.BspLumps
             }
             catch (InvalidDataException e)
             {
-                Console.WriteLine(
+                logger.LogWarning(
                     "WARNING: Failed to parse entity: {0}, {1} in list.\n Saving this BSP could cause data loss!",
                     e.Message, Data.Count);
 
@@ -125,7 +128,7 @@ namespace Lumper.Lib.BSP.Lumps.BspLumps
                     }
                 }
                 if (!foundEnd)
-                    Console.WriteLine("WARNING: End of entity not found!");
+                    logger.LogWarning("WARNING: End of entity not found!");
             }
 
             return false;

--- a/src/Lumper/BSP/Lumps/BspLumps/PakFileLump.cs
+++ b/src/Lumper/BSP/Lumps/BspLumps/PakFileLump.cs
@@ -2,13 +2,12 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 using SharpCompress.Writers;
 using SharpCompress.Common;
 using SharpCompress.Archives.Zip;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Lumper.Lib.BSP.Struct;
+using Microsoft.Extensions.Logging;
 
 namespace Lumper.Lib.BSP.Lumps.BspLumps
 {
@@ -122,7 +121,8 @@ namespace Lumper.Lib.BSP.Lumps.BspLumps
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex.Message);
+                var logger = LumperLoggerFactory.GetInstance().CreateLogger(GetType());
+                logger.LogError(ex.Message);
             }
         }
 

--- a/src/Lumper/BSP/Lumps/GameLumps/Sprp.cs
+++ b/src/Lumper/BSP/Lumps/GameLumps/Sprp.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 
@@ -12,6 +13,8 @@ namespace Lumper.Lib.BSP.Lumps.GameLumps
         { }
         public override void Read(BinaryReader reader, long length)
         {
+            var logger = LumperLoggerFactory.GetInstance().CreateLogger(GetType());
+
             var startPos = reader.BaseStream.Position;
 
             int dictEntries = reader.ReadInt32();
@@ -35,7 +38,7 @@ namespace Lumper.Lib.BSP.Lumps.GameLumps
                     if (remainingLength % StaticProps.StructureSize != 0)
                     {
                         StaticProps.ActualVersion = StaticPropVersion.V7s;
-                        Console.WriteLine($"Remaining length doesn't fit version {Version} .. trying V7*");
+                        logger.LogInformation($"Remaining length doesn't fit version {Version} .. trying V7*");
                     }
                     break;
             }

--- a/src/Lumper/BSP/Lumps/GameLumps/StaticPropDictLump.cs
+++ b/src/Lumper/BSP/Lumps/GameLumps/StaticPropDictLump.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using System;
 using System.IO;
 using System.Text;
@@ -19,7 +20,8 @@ namespace Lumper.Lib.BSP.Lumps.GameLumps
             var count = value.Length;
             if (count > StructureSize)
             {
-                Console.WriteLine($"WARNING: {this.GetType().Name} string to long");
+                var logger = LumperLoggerFactory.GetInstance().CreateLogger(GetType());
+                logger.LogWarning($"WARNING: {this.GetType().Name} string to long");
                 count = StructureSize;
             }
             Array.Copy(value, b, count);

--- a/src/Lumper/BSP/Struct/Entity.cs
+++ b/src/Lumper/BSP/Struct/Entity.cs
@@ -1,6 +1,6 @@
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Lumper.Lib.BSP.Struct
 {
@@ -40,7 +40,8 @@ namespace Lumper.Lib.BSP.Struct
                     }
                     catch (Exception e) when (e is IndexOutOfRangeException || e is FormatException)
                     {
-                        Console.WriteLine($"Failed to pass entity IO value '{key}' '{value}'!");
+                        var logger = LumperLoggerFactory.GetInstance().CreateLogger<Property>();
+                        logger.LogError($"Failed to pass entity IO value '{key}' '{value}'!");
                     }
                 }
                 return new Property<string>(key, value);
@@ -70,6 +71,8 @@ namespace Lumper.Lib.BSP.Struct
 
         public Entity(IEnumerable<KeyValuePair<string, string>> keyValues)
         {
+            var logger = LumperLoggerFactory.GetInstance().CreateLogger(GetType());
+
             foreach (var kv in keyValues)
             {
                 if (kv.Key == "classname")
@@ -81,13 +84,13 @@ namespace Lumper.Lib.BSP.Struct
                         continue;
                     }
                     else
-                        Console.WriteLine("Found duplicate classname key, ignoring {0}", kv);
+                        logger.LogInformation("Found duplicate classname key, ignoring {0}", kv);
                 }
                 Properties.Add(Property.CreateProperty(kv));
             }
 
             if (ClassName is null)
-                Console.WriteLine("Warning: Found entity with missing classname!");
+                logger.LogWarning("Warning: Found entity with missing classname!");
         }
     }
 }

--- a/src/Lumper/LoggerFactory.cs
+++ b/src/Lumper/LoggerFactory.cs
@@ -1,0 +1,124 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+
+namespace Lumper
+{
+    public class LumperLoggerFactory : ILoggerFactory
+    {
+        private static LumperLoggerFactory _instance;
+
+        private ILoggerFactory _defaultLoggerFactory;
+
+        static LumperLoggerFactory()
+        {
+            _instance = new LumperLoggerFactory();
+
+        }
+
+        private LumperLoggerFactory()
+        {
+            _defaultLoggerFactory = LoggerFactory.Create(
+                    builder =>
+                    {
+                        builder.AddConsole();
+                        builder.AddProvider(new LumperUILoggerProvider());
+                    }
+                );
+        }
+
+        public static ILoggerFactory GetInstance()
+        {
+            return _instance;
+        }
+
+        public void AddProvider(ILoggerProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            var logger = _defaultLoggerFactory.CreateLogger(categoryName);
+
+            return logger;
+        }
+
+        public void Dispose()
+        {
+            _defaultLoggerFactory?.Dispose();
+        }
+    }
+
+    public class LumperUILoggerProvider : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName)
+        {
+            return LumperUILogger.GetInstance();
+        }
+
+        public void Dispose()
+        {
+            
+        }
+    }
+
+    public class LumperUILogger : ILogger
+    {
+        public event MyEventHandler? LogCreatedEvent;
+
+        public delegate void LogCreated();  
+
+        private static LumperUILogger _lumperUILogger;
+
+        static LumperUILogger()
+        {
+            _lumperUILogger = new LumperUILogger();
+        }
+
+        private LumperUILogger()
+        {
+
+        }
+
+        public static LumperUILogger GetInstance()
+        {
+            return _lumperUILogger;
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            LogCreatedEvent?.Invoke(this, new LogEvent(logLevel, message: state.ToString()));
+        }
+
+        public delegate void MyEventHandler(object sender, LogEvent e);
+    }
+
+    public class LogEvent 
+    {
+        public DateTime DateTime { get; set; }
+        public LogLevel LogLevel { get; set; }
+        public string Message { get; set; }
+
+        public bool IsError => LogLevel == LogLevel.Error;
+        public bool IsWarning => LogLevel == LogLevel.Warning;
+
+        public LogEvent(LogLevel logLevel, string message)
+        {
+            DateTime = DateTime.Now;
+            LogLevel = logLevel;
+            Message = message;
+        }
+
+
+    }
+}

--- a/src/Lumper/Lumper.csproj
+++ b/src/Lumper/Lumper.csproj
@@ -8,7 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SharpCompress" Version="0.32.2" />
   </ItemGroup>

--- a/src/Lumper/LumperCodeExecutionHelper.cs
+++ b/src/Lumper/LumperCodeExecutionHelper.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace Lumper
+{
+    public class LumperCodeExecutionHelper
+    {
+        protected ILogger _logger;
+
+        public LumperCodeExecutionHelper()
+        {
+            _logger = LumperLoggerFactory.GetInstance().CreateLogger(GetType());
+        }
+
+        public async Task ExecuteAndLogError(Func<Task> task)
+        {
+            try
+            {
+                await task();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, ex.Message);
+            }
+        }
+    }
+}

--- a/src/Lumper/Tasks/ChangeTextureTask.cs
+++ b/src/Lumper/Tasks/ChangeTextureTask.cs
@@ -1,8 +1,8 @@
-using System;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using Lumper.Lib.BSP;
 using Lumper.Lib.BSP.Lumps.BspLumps;
+using Microsoft.Extensions.Logging;
 
 namespace Lumper.Lib.Tasks
 {
@@ -19,11 +19,11 @@ namespace Lumper.Lib.Tasks
             Progress.Max = texDataLump.Data.Count;
             foreach (var texture in texDataLump.Data)
             {
-                Console.Write($"TexName: {texture.TexName}");
+                _logger.LogInformation($"TexName: {texture.TexName}");
                 if (Replace.ContainsKey(texture.TexName))
                 {
                     texture.TexName = Replace[texture.TexName];
-                    Console.Write($" replace: {texture.TexName}");
+                    _logger.LogInformation($" replace: {texture.TexName}");
                 }
                 else
                 {
@@ -36,11 +36,11 @@ namespace Lumper.Lib.Tasks
                         if (texture.TexName != tmp)
                         {
                             texture.TexName = tmp;
-                            Console.Write($" replaceRegex: {texture.TexName}");
+                            _logger.LogInformation($" replaceRegex: {texture.TexName}");
                         }
                     }
                 }
-                Console.WriteLine();
+                _logger.LogInformation("");
                 Progress.Count++;
             }
             return TaskResult.Success;

--- a/src/Lumper/Tasks/CompressionTask.cs
+++ b/src/Lumper/Tasks/CompressionTask.cs
@@ -1,6 +1,6 @@
-using System;
 using Lumper.Lib.BSP;
 using Lumper.Lib.BSP.Lumps.BspLumps;
+using Microsoft.Extensions.Logging;
 
 namespace Lumper.Lib.Tasks
 {
@@ -30,7 +30,7 @@ namespace Lumper.Lib.Tasks
             int i = 0;
             foreach (var lump in map.Lumps)
             {
-                Console.WriteLine($"{i} {lump.Key} {lump.Value.GetType().Name}");
+                _logger.LogInformation($"{i} {lump.Key} {lump.Value.GetType().Name}");
                 i++;
 
                 if (lump.Value is not GameLump && lump.Value is not PakFileLump)

--- a/src/Lumper/Tasks/RunExternalToolTask.cs
+++ b/src/Lumper/Tasks/RunExternalToolTask.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Lumper.Lib.BSP;
+using Microsoft.Extensions.Logging;
 
 namespace Lumper.Lib.Tasks
 {
@@ -83,7 +84,7 @@ namespace Lumper.Lib.Tasks
                 Progress.Max = fiIn.Length;
             }
             else
-                Console.WriteLine($"Warning: Inputfile not set for external command '{Path} {Args}'");
+                _logger.LogWarning($"Warning: Inputfile not set for external command '{Path} {Args}'");
 
             if (File.Exists(OutputFile))
                 File.Delete(OutputFile);
@@ -154,7 +155,7 @@ namespace Lumper.Lib.Tasks
                 else
                     stream = stdOut.Mem;
                 var r = new StreamReader(stream);
-                Console.WriteLine($"{System.IO.Path.GetFileName(Path)} ERROR: {r.ReadToEnd()}");
+                _logger.LogError($"{System.IO.Path.GetFileName(Path)} ERROR: {r.ReadToEnd()}");
             }
             return ret;
         }

--- a/src/Lumper/Tasks/Task.cs
+++ b/src/Lumper/Tasks/Task.cs
@@ -1,6 +1,7 @@
 using Newtonsoft.Json;
 using JsonSubTypes;
 using Lumper.Lib.BSP;
+using Microsoft.Extensions.Logging;
 
 namespace Lumper.Lib.Tasks
 {
@@ -9,11 +10,18 @@ namespace Lumper.Lib.Tasks
     [JsonConverter(typeof(JsonSubtypes), "Type")]
     public abstract class LumperTask
     {
+        protected ILogger _logger;
+
         public abstract string Type { get; }
 
         [JsonIgnore]
         public TaskProgress Progress { get; protected set; } = new();
 
         public abstract TaskResult Run(BspFile map);
+
+        public LumperTask()
+        {
+            _logger = LumperLoggerFactory.GetInstance().CreateLogger(GetType());
+        }
     }
 }


### PR DESCRIPTION
# Description
Improved logging and error handling

# What was done
* Replaced Console.Writeline with ILogger
* Added Logger Factory and ILogger
   * Create log anywhere using `LumperLoggerFactory.GetInstance().CreateLogger(GetType()).LogInformation("My Log");`
* Wrap any code to handle error logging on exceptions using
```
await new LumperCodeExecutionHelper().ExecuteAndLogError(async () =>
{
   // Any code here
});
```
* Wrapped some existing UI commands with `await new LumperCodeExecutionHelper().ExecuteAndLogError` to catch and log errors
* Created view in UI to show logs
   * Menu: `View --> Logs`
   * This view is shown when application starts
   * Error logs triggers a switch to this view
   
# UI
Example of loading a file that is not a bsp file
![image](https://github.com/momentum-mod/lumper/assets/162886876/8c5a3aa4-5085-49a9-81c4-7b4605a7bfef)


