### PR TITLE
Curly bracket removal / vscript values output fix

### DIFF
--- a/src/Lumper.Lib/BSP/Lumps/BspLumps/EntityLump.cs
+++ b/src/Lumper.Lib/BSP/Lumps/BspLumps/EntityLump.cs
@@ -55,6 +55,10 @@ public class EntityLump(BspFile parent) : ManagedLump<BspLumpType>(parent)
                             Data.Add(new Entity(keyValues) { EntityLumpVersion = Version });
                             return true;
                         }
+                        else
+                        {
+                            stringBuilder.Append(x);
+                        }
 
                         break;
 
@@ -64,6 +68,8 @@ public class EntityLump(BspFile parent) : ManagedLump<BspLumpType>(parent)
 
                         if (!inString)
                             inSection = true;
+                        else
+                            stringBuilder.Append(x);
 
                         break;
 


### PR DESCRIPTION
Closes https://github.com/momentum-mod/lumper/issues/53

Curly brackets are currently being treated as special characters that only signify the start and end of sections, but they can appear in any entity - for instance, a valid entity name is {a} - this pr should fix this. (Regarding changes made to EntityLump.cs)

The second part of the change is regarding vscript outputs not saving correctly - previously, commas were used to delimit but when a file is compiled to use vscript, it instead uses \u001b but this was not being taken into account when writing the string to the disk, and as such was being loaded incorrectly (as a regular key/value pair rather than as a specific EntityIO) (Regarding changes made to EntityIO.cs)

Here's a bsp I made for TF2 to test this issue: https://filebin.net/5az4cvzf7mik93ys and it now loads and saves the values correctly (vscript is on the func_button, targetting 'test' with an input of RunScriptCode).
 