### PR TITLE
Default cubemap renaming

### DIFF
--- a/src/Lumper.Lib/BSP/BspFile.cs
+++ b/src/Lumper.Lib/BSP/BspFile.cs
@@ -105,6 +105,15 @@ public sealed partial class BspFile : IDisposable
         if (path is null && FilePath is null)
             throw new ArgumentException("Not given a path to write to, and current BSP doesn't have a path");
 
+        if (path != null && Path.GetFileName(path) != FilePath)
+        {
+            PakfileLump pakfile = GetLump<PakfileLump>();
+
+            Dictionary<string, string> modified = pakfile.RenameCubemapsPath(Path.GetFileName(path));
+            foreach (KeyValuePair<string,string> modifiedPath in modified)
+                pakfile.UpdatePathReferences(modifiedPath.Value, modifiedPath.Key);
+        }
+
         string outPath;
         string? backupPath = null;
 

--- a/src/Lumper.Lib/BSP/BspFile.cs
+++ b/src/Lumper.Lib/BSP/BspFile.cs
@@ -111,7 +111,7 @@ public sealed partial class BspFile : IDisposable
 
             Dictionary<string, string> modified = pakfile.RenameCubemapsPath(Path.GetFileName(path));
             foreach (KeyValuePair<string,string> modifiedPath in modified)
-                pakfile.UpdatePathReferences(modifiedPath.Value, modifiedPath.Key);
+                pakfile.UpdatePathReferences(modifiedPath.Value, modifiedPath.Key, ".vmt");
         }
 
         string outPath;

--- a/src/Lumper.Lib/BSP/Lumps/BspLumps/EntityLump.cs
+++ b/src/Lumper.Lib/BSP/Lumps/BspLumps/EntityLump.cs
@@ -42,7 +42,7 @@ public class EntityLump(BspFile parent) : ManagedLump<BspLumpType>(parent)
             var inSection = false;
             var inString = false;
             char x;
-            while (reader.BaseStream.Position < reader.BaseStream.Length && (x = reader.ReadChar()) != '\0')
+            while (reader.BaseStream.Position < reader.BaseStream.Length && (x = (char)reader.ReadByte()) != '\0')
             {
                 switch (x)
                 {
@@ -143,16 +143,18 @@ public class EntityLump(BspFile parent) : ManagedLump<BspLumpType>(parent)
     {
         foreach (Entity ent in Data)
         {
-            stream.Write(Encoding.ASCII.GetBytes("{\n"));
+            // 28591 is extended ASCII - https://en.wikipedia.org/wiki/Extended_ASCII
+            // Encoding.ASCII is *7-bit* whereas 28591 is 8 bit - important as 8-bit ASCII is what the format uses
+            stream.Write(Encoding.GetEncoding(28591).GetBytes("{\n"));
             foreach (Entity.EntityProperty prop in ent.Properties)
             {
-                stream.Write(Encoding.ASCII.GetBytes($"{prop}\n"));
+                stream.Write(Encoding.GetEncoding(28591).GetBytes($"{prop}\n"));
             }
 
-            stream.Write(Encoding.ASCII.GetBytes("}\n"));
+            stream.Write(Encoding.GetEncoding(28591).GetBytes("}\n"));
         }
 
-        stream.Write(Encoding.ASCII.GetBytes("\0"));
+        stream.Write(Encoding.GetEncoding(28591).GetBytes("\0"));
     }
 
     public override bool Empty => Data.Count == 0;

--- a/src/Lumper.Lib/BSP/Lumps/BspLumps/PakFileLump.cs
+++ b/src/Lumper.Lib/BSP/Lumps/BspLumps/PakFileLump.cs
@@ -49,7 +49,7 @@ public partial class PakfileLump(BspFile parent) : ManagedLump<BspLumpType>(pare
     /// Updates all path references in the PakFileLump from oldPath to newPath,
     /// i.e. if a VMT references a VTF, it will be updated.
     /// </summary>
-    public void UpdatePathReferences(string newPath, string oldPath)
+    public void UpdatePathReferences(string newPath, string oldPath, string? limitExtension = null)
     {
         var opSplit = oldPath.Split('/');
         var npSplit = newPath.Split('/');
@@ -62,6 +62,8 @@ public partial class PakfileLump(BspFile parent) : ManagedLump<BspLumpType>(pare
 
         foreach (PakfileEntry entry in Entries)
         {
+            if (limitExtension is null || !entry.Key.EndsWith(limitExtension))
+                continue;
 
             var entryString = Encoding.Default.GetString(entry.GetReadOnlyStream().ToArray());
             var newString = entryString.Replace(oldPath, newPath, StringComparison.OrdinalIgnoreCase);

--- a/src/Lumper.Lib/BSP/Lumps/BspLumps/PakFileLump.cs
+++ b/src/Lumper.Lib/BSP/Lumps/BspLumps/PakFileLump.cs
@@ -105,11 +105,14 @@ public partial class PakfileLump(BspFile parent) : ManagedLump<BspLumpType>(pare
         string baseFilename = Path.GetFileNameWithoutExtension(newFileName);
         var entriesModified = new Dictionary<string, string>();
 
+        bool matched = false;
         foreach (PakfileEntry entry in Entries)
         {
             Match match = CubemapRegex().Match(entry.Key);
             if (match.Success)
             {
+                matched = true;
+
                 // Add the old key so we can update the UI later
                 var oldString = entry.Key;
 
@@ -120,8 +123,13 @@ public partial class PakfileLump(BspFile parent) : ManagedLump<BspLumpType>(pare
                 entriesModified.Add(oldString, entry.Key);
             }
         }
-        IsModified = true;
-        UpdateZip();
+
+        if (matched)
+        {
+            IsModified = true;
+            UpdateZip();
+        }
+
         return entriesModified;
     }
 

--- a/src/Lumper.Lib/BSP/Lumps/BspLumps/PakFileLump.cs
+++ b/src/Lumper.Lib/BSP/Lumps/BspLumps/PakFileLump.cs
@@ -42,7 +42,7 @@ public partial class PakfileLump(BspFile parent) : ManagedLump<BspLumpType>(pare
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
     // As per https://github.com/ValveSoftware/source-sdk-2013/blob/master/mp/src/utils/vbsp/cubemap.cpp
-    [GeneratedRegex(@"materials\/maps\/(.+)/?(?:(?:c-?\d+_-?\d+_-?\d+)|(?:cubemapdefault)(?:\.hdr)?\.vtf)")]
+    [GeneratedRegex(@"materials\/maps\/(.+)?/(?:(?:c-?\d+_-?\d+_-?\d+)|(?:cubemapdefault)(?:\.hdr)?\.vtf)")]
     private static partial Regex CubemapRegex();
 
     /// <summary>

--- a/src/Lumper.Lib/BSP/Lumps/BspLumps/PakFileLump.cs
+++ b/src/Lumper.Lib/BSP/Lumps/BspLumps/PakFileLump.cs
@@ -1,9 +1,12 @@
 namespace Lumper.Lib.BSP.Lumps.BspLumps;
 
+using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 using Bsp.Enum;
 using Enum;
 using IO;
@@ -20,7 +23,7 @@ using Struct;
 /// The pakfile lump (aka paklump) is just a zip archive for storing assets in the BSP.
 /// The overall archive is always uncompressed, but each item may be LZMA compressed.
 /// </summary>
-public class PakfileLump(BspFile parent) : ManagedLump<BspLumpType>(parent), IFileBackedLump
+public partial class PakfileLump(BspFile parent) : ManagedLump<BspLumpType>(parent), IFileBackedLump
 {
     public List<PakfileEntry> Entries { get; private set; } = [];
 
@@ -37,6 +40,88 @@ public class PakfileLump(BspFile parent) : ManagedLump<BspLumpType>(parent), IFi
     public ZipArchive Zip { get; private set; } = null!;
 
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+    // As per https://github.com/ValveSoftware/source-sdk-2013/blob/master/mp/src/utils/vbsp/cubemap.cpp
+    [GeneratedRegex(@"materials\/maps\/(.+)/?(?:(?:c-?\d+_-?\d+_-?\d+)|(?:cubemapdefault)(?:\.hdr)?\.vtf)")]
+    private static partial Regex CubemapRegex();
+
+    /// <summary>
+    /// Updates all path references in the PakFileLump from oldPath to newPath,
+    /// i.e. if a VMT references a VTF, it will be updated.
+    /// </summary>
+    public void UpdatePathReferences(string newPath, string oldPath)
+    {
+        var opSplit = oldPath.Split('/');
+        var npSplit = newPath.Split('/');
+
+        // VMTs can reference VTFs ignoring the root directory and without the extension
+        oldPath = string.Join('/', opSplit[1..]);
+        newPath = string.Join('/', npSplit[1..]);
+        oldPath = Path.ChangeExtension(oldPath, "").TrimEnd('.');
+        newPath = Path.ChangeExtension(newPath, "").TrimEnd('.');
+
+        foreach (PakfileEntry entry in Entries)
+        {
+
+            var entryString = Encoding.Default.GetString(entry.GetReadOnlyStream().ToArray());
+            var newString = entryString.Replace(oldPath, newPath, StringComparison.OrdinalIgnoreCase);
+
+            if (newString != entryString)
+                entry.UpdateData(Encoding.Default.GetBytes(newString));
+        }
+    }
+    /// <summary>
+    /// Gets the default cubemap path as Source uses the filename when searching.
+    /// Returns a dictionary with the key as the old string
+    /// and the value as the new string
+    /// </summary>
+    public Dictionary<string, string> GetCubemapsToChange(string newFileName)
+    {
+        string baseFilename = Path.GetFileNameWithoutExtension(newFileName);
+        var entriesModified = new Dictionary<string, string>();
+
+        foreach (PakfileEntry entry in Entries)
+        {
+            Match match = CubemapRegex().Match(entry.Key);
+            if (match.Success)
+            {
+                var cubemapName = match.Groups[1].Value;
+                entriesModified.Add(entry.Key, entry.Key.Replace(cubemapName, baseFilename));
+            }
+        }
+
+        return entriesModified;
+    }
+
+    /// <summary>
+    /// Renames the cubemap path as Source uses the filename when searching.
+    /// Returns a dictionary with the key as the old string
+    /// and the value as the new string
+    /// </summary>
+    public Dictionary<string,string> RenameCubemapsPath(string newFileName)
+    {
+        string baseFilename = Path.GetFileNameWithoutExtension(newFileName);
+        var entriesModified = new Dictionary<string, string>();
+
+        foreach (PakfileEntry entry in Entries)
+        {
+            Match match = CubemapRegex().Match(entry.Key);
+            if (match.Success)
+            {
+                // Add the old key so we can update the UI later
+                var oldString = entry.Key;
+
+                var cubemapName = match.Groups[1].Value;
+                entry.Key = entry.Key.Replace(cubemapName, baseFilename);
+                entry.IsModified = true;
+
+                entriesModified.Add(oldString, entry.Key);
+            }
+        }
+        IsModified = true;
+        UpdateZip();
+        return entriesModified;
+    }
 
     public override void Read(BinaryReader reader, long length, IoHandler? handler = null)
     {

--- a/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileLumpViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileLumpViewModel.cs
@@ -30,13 +30,18 @@ public sealed class PakfileLumpViewModel : BspNode, ILumpViewModel
 
         InitEntries();
     }
-
-    private void InitEntries()
-        => Entries.Edit(updater =>
+    public void UpdateEntries(bool checkIfModified)
+    => Entries.Edit(updater =>
+    {
+        foreach (PakfileEntry entry in _pakfile.Entries.OrderBy(x => new FileInfo(x.Key).Name))
         {
-            foreach (PakfileEntry entry in _pakfile.Entries.OrderBy(x => new FileInfo(x.Key).Name))
+            if (entry.IsModified || !checkIfModified)
                 updater.AddOrUpdate(CreateEntryViewModel(entry));
-        });
+        }
+    });
+
+    private void InitEntries() =>
+        UpdateEntries(false);
 
     private PakfileEntryViewModel CreateEntryViewModel(PakfileEntry entry)
         => entry.Key.EndsWith(".vtf", StringComparison.OrdinalIgnoreCase)
@@ -241,6 +246,7 @@ public sealed class PakfileLumpViewModel : BspNode, ILumpViewModel
                     entry.Content = entry.Content[..matchIndex] + updatedNp +
                                     entry.Content[(matchIndex + updatedOp.Length)..];
                     changes++;
+                    entry.IsModified = true;
                 }
                 else
                 {
@@ -259,6 +265,7 @@ public sealed class PakfileLumpViewModel : BspNode, ILumpViewModel
                         entry.Content[(wholeMatchIndex + updatedOp.Length)..];
 
                     changes++;
+                    entry.IsModified = true;
                 }
             }
 


### PR DESCRIPTION
Fix for this issue: https://github.com/momentum-mod/lumper/issues/60

Didn't use ```CubemapRegex``` as matching cX_cY_cZ as well will cause false positives. (Unless I'm misunderstanding how that works)