### PR TITLE
Run various editorconfig style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -242,9 +242,10 @@ dotnet_diagnostic.CA1822.severity = suggestion
 # making a separate property and making the class partial just for this.
 dotnet_diagnostic.SYSLIB1045.severity = suggestion
 
-# Formatting rules are omitted / disabled - CSharpier handles everything.
-dotnet_diagnostic.IDE0055.severity = none
-dotnet_analyzer_diagnostic.category-Style.severity = none
+# Formatting rules that are handled by CSharpier. Unfortunately `dotnet format style` includes a *lot* more than
+# style stuff.
+dotnet_diagnostic.IDE0011.severity = none # "Add braces"
+dotnet_diagnostic.IDE0055.severity = none # "Fix formatting"
 
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#net-formatting-rules
 # Dotnet namespace options

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,10 @@ jobs:
       with:
         dotnet-version: 8.0.x
 
-    - name: Check dotnet analyzers
-      run: dotnet format analyzers --verify-no-changes
+    - name: Check dotnet format
+      run: |
+        dotnet format analyzers --verify-no-changes && \
+        dotnet format style --verify-no-changes
 
     - name: Check csharpier formatting
       run: dotnet tool restore && dotnet csharpier . --check

--- a/src/Lumper.CLI/CommandLineOptions.cs
+++ b/src/Lumper.CLI/CommandLineOptions.cs
@@ -72,7 +72,7 @@ public class CommandLineOptions
     [Option(
         'k',
         "jsonOpts",
-        Default = CLI.JsonOptions.SortLumps | CLI.JsonOptions.SortProperties | CLI.JsonOptions.IgnoreOffset,
+        Default = JsonOptions.SortLumps | JsonOptions.SortProperties | JsonOptions.IgnoreOffset,
         Required = false,
         HelpText = "Provide either flags (1 = Sort Lumps, 2 = Sort Properties, 4 = Ignore Offsets),"
             + " or comma-separator list of names, e.g. sortproperties,ignoreoffsets."

--- a/src/Lumper.CLI/Program.cs
+++ b/src/Lumper.CLI/Program.cs
@@ -68,11 +68,8 @@ internal sealed class Program
     // If method completes successfully, the program will exit with status code 0.
     private static void Run(CommandLineOptions options)
     {
-        var bspFile = BspFile.FromPath(options.InputPath, null);
-
-        if (bspFile is null)
-            throw new InvalidDataException("Failed to load BSP file");
-
+        BspFile bspFile =
+            BspFile.FromPath(options.InputPath, null) ?? throw new InvalidDataException("Failed to load BSP file");
         if (options.JobWorkflow is { } workflowPath)
             RunWorkflow(bspFile, workflowPath);
 

--- a/src/Lumper.Lib/BSP/Struct/PakFileEntry.cs
+++ b/src/Lumper.Lib/BSP/Struct/PakFileEntry.cs
@@ -69,7 +69,7 @@ public sealed class PakfileEntry : IDisposable
     private readonly object _instanceLock = new();
 
     // Static lock for access to zip archive - SharpCompress's OpenEntryStream is not thread-safe.
-    private static readonly object _zipAccessLock = new();
+    private static readonly object ZipAccessLock = new();
 
     /// <summary>
     /// Get an stream to the uncompressed pakfile entry.
@@ -93,7 +93,7 @@ public sealed class PakfileEntry : IDisposable
             else
             {
                 MemoryStream outStream;
-                lock (_zipAccessLock)
+                lock (ZipAccessLock)
                 {
                     using Stream zipStream = ZipEntry!.OpenEntryStream();
                     outStream = new MemoryStream();

--- a/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryVtfViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryVtfViewModel.cs
@@ -155,7 +155,7 @@ public class PakfileEntryVtfViewModel : PakfileEntryViewModel
         HasSeparateWindow = true;
     }
 
-    private static Bitmap ImageToBitmap(Image<Rgba32> image, int? size = null)
+    private static Bitmap ImageToBitmap(Image<Rgba32> image)
     {
         using var mem = new MemoryStream();
         image.SaveAsBmp(mem, Encoder);


### PR DESCRIPTION
Realised we hadn't been enforcing these since `dotnet format style` covers so much non-formatting related stuff. I'm so tired of this editorconfig file!