### PR TITLE
Automatic Updating

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
 
     - name: Check dotnet format
       run: |

--- a/BuildShared.props
+++ b/BuildShared.props
@@ -1,8 +1,9 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <AssemblyVersion>$(Version)</AssemblyVersion>
     <TargetFramework>net8.0</TargetFramework>
+    <AssemblyVersion Condition=" '$(Version)' == '' ">0.0.0</AssemblyVersion>
+    <AssemblyVersion Condition=" '$(Version)' != '' ">$(Version)</AssemblyVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -73,9 +73,7 @@ diffing BSP versions in Git.
 ## Download
 
 See the [Releases](https://github.com/momentum-mod/lumper/releases) tab on the
-right! This program is very new, and we
-don't currently have any kind of auto-updater, so worth checking back here for
-updates regularly.
+right! The UI application will automatically offer updates when launched.
 
 ## Momentum
 

--- a/src/Lumper.CLI/Lumper.CLI.csproj
+++ b/src/Lumper.CLI/Lumper.CLI.csproj
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <ApplicationIcon>..\Lumper.UI\Assets\Images\Lumper.ico</ApplicationIcon>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Lumper.CLI/Lumper.CLI.csproj
+++ b/src/Lumper.CLI/Lumper.CLI.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1"/>
-    <PackageReference Include="NLog" Version="5.3.2"/>
+    <PackageReference Include="NLog" Version="5.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lumper.Lib/BSP/Struct/PakFileEntry.cs
+++ b/src/Lumper.Lib/BSP/Struct/PakFileEntry.cs
@@ -140,6 +140,5 @@ public sealed class PakfileEntry : IDisposable
     public void Dispose() => DisposeIssuedStreams();
 
     // Deliberately not [JsonIgnore]ed so we expose this to JSON dumps.
-    public string HashSHA1 =>
-        BitConverter.ToString(SHA1.Create().ComputeHash(GetReadOnlyStream())).Replace("-", string.Empty);
+    public string HashSHA1 => Convert.ToHexString(SHA1.Create().ComputeHash(GetReadOnlyStream()));
 }

--- a/src/Lumper.Lib/BSP/Struct/PakFileEntry.cs
+++ b/src/Lumper.Lib/BSP/Struct/PakFileEntry.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
+using System.Threading;
 using Lumper.Lib.Bsp.Lumps.BspLumps;
 using Newtonsoft.Json;
 using SharpCompress.Archives.Zip;
@@ -66,10 +67,10 @@ public sealed class PakfileEntry : IDisposable
     [JsonIgnore]
     // Instance lock for access to buffer and issued streams, ensuring original data is read from
     // zip thread-safely, and that new streams are not issued as data is being replaced.
-    private readonly object _instanceLock = new();
+    private readonly Lock _instanceLock = new();
 
     // Static lock for access to zip archive - SharpCompress's OpenEntryStream is not thread-safe.
-    private static readonly object ZipAccessLock = new();
+    private static readonly Lock ZipAccessLock = new();
 
     /// <summary>
     /// Get an stream to the uncompressed pakfile entry.

--- a/src/Lumper.Lib/Lumper.Lib.csproj
+++ b/src/Lumper.Lib/Lumper.Lib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Lumper.Lib/Lumper.Lib.csproj
+++ b/src/Lumper.Lib/Lumper.Lib.csproj
@@ -8,8 +8,8 @@
   <ItemGroup>
     <PackageReference Include="JsonSubTypes" Version="2.0.1"/>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-    <PackageReference Include="NLog" Version="5.3.2"/>
-    <PackageReference Include="SharpCompress" Version="0.37.2"/>
+    <PackageReference Include="NLog" Version="5.3.4" />
+    <PackageReference Include="SharpCompress" Version="0.39.0"/>
   </ItemGroup>
 
 </Project>

--- a/src/Lumper.UI/Lumper.UI.csproj
+++ b/src/Lumper.UI/Lumper.UI.csproj
@@ -4,10 +4,11 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ApplicationIcon>Assets\Images\Lumper.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    <LangVersion>13</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Lumper.UI/Lumper.UI.csproj
+++ b/src/Lumper.UI/Lumper.UI.csproj
@@ -17,21 +17,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.1.2" />
+    <PackageReference Include="Avalonia" Version="11.2.3" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.1.0" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.1.2" />
-    <PackageReference Include="Avalonia.Controls.TreeDataGrid" Version="11.0.10"/>
-    <PackageReference Include="Avalonia.Desktop" Version="11.1.2" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.3" />
+    <PackageReference Include="Avalonia.Controls.TreeDataGrid" Version="11.1.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.2.3" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.2" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.1.2" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.2" />
-    <PackageReference Include="MessageBox.Avalonia" Version="3.1.6" />
-    <PackageReference Include="ReactiveUI" Version="20.1.1"/>
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.3" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.2.3" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.3" />
+    <PackageReference Include="MessageBox.Avalonia" Version="3.2.0" />
+    <PackageReference Include="ReactiveUI" Version="20.1.63" />
     <PackageReference Include="ReactiveUI.Fody" Version="19.5.41"/>
-    <PackageReference Include="Material.Icons.Avalonia" Version="2.1.10" />
-    <PackageReference Include="NLog" Version="5.3.2"/>
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
+    <PackageReference Include="Material.Icons.Avalonia" Version="2.2.0" />
+    <PackageReference Include="NLog" Version="5.3.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
+    <PackageReference Include="SharpCompress" Version="0.39.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lumper.UI/Program.cs
+++ b/src/Lumper.UI/Program.cs
@@ -3,6 +3,7 @@ namespace Lumper.UI;
 using System;
 using System.Diagnostics;
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.ReactiveUI;
 using NLog;
@@ -57,4 +58,9 @@ internal sealed class Program
             return desktop;
         }
     }
+
+    // MainWindow should never be null given we use Avalonia,
+    // null checks are extremely annoying when using message boxes.
+    public static Window MainWindow =>
+        Desktop.MainWindow ?? throw new InvalidOperationException("MainWindow is null somehow!");
 }

--- a/src/Lumper.UI/Services/BspService.cs
+++ b/src/Lumper.UI/Services/BspService.cs
@@ -132,15 +132,12 @@ public sealed class BspService : ReactiveObject
             var cts = new CancellationTokenSource();
             var handler = new IoHandler(cts);
 
-            if (Program.Desktop.MainWindow is not null)
+            progressWindow = new IoProgressWindow
             {
-                progressWindow = new IoProgressWindow
-                {
-                    Title = $"Loading {Path.GetFileName(pathOrUrl)}",
-                    Handler = handler,
-                };
-                _ = progressWindow.ShowDialog(Program.Desktop.MainWindow);
-            }
+                Title = $"Loading {Path.GetFileName(pathOrUrl)}",
+                Handler = handler,
+            };
+            _ = progressWindow.ShowDialog(Program.MainWindow);
 
             BspFile = outStream is not null
                 ? await Observable.Start(() => BspFile.FromStream(outStream, handler), RxApp.TaskpoolScheduler)
@@ -181,11 +178,8 @@ public sealed class BspService : ReactiveObject
         var stream = new MemoryStream();
         try
         {
-            if (Program.Desktop.MainWindow is not null)
-            {
-                progressWindow = new IoProgressWindow { Title = $"Downloading {url}", Handler = handler };
-                _ = progressWindow.ShowDialog(Program.Desktop.MainWindow);
-            }
+            progressWindow = new IoProgressWindow { Title = $"Downloading {url}", Handler = handler };
+            _ = progressWindow.ShowDialog(Program.MainWindow);
 
             using var httpClient = new HttpClient();
             using HttpResponseMessage response = await httpClient.GetAsync(
@@ -277,15 +271,8 @@ public sealed class BspService : ReactiveObject
 
             string outName = outFile is not null ? Path.GetFileName(outFile.Path.AbsolutePath) : FileName!;
 
-            if (Program.Desktop.MainWindow is not null)
-            {
-                progressWindow = new IoProgressWindow
-                {
-                    Title = $"Saving {outName} ({compressString})",
-                    Handler = handler,
-                };
-                _ = progressWindow.ShowDialog(Program.Desktop.MainWindow);
-            }
+            progressWindow = new IoProgressWindow { Title = $"Saving {outName} ({compressString})", Handler = handler };
+            _ = progressWindow.ShowDialog(Program.MainWindow);
 
             // get the cubemaps that will be changed
 

--- a/src/Lumper.UI/Services/UpdaterService.cs
+++ b/src/Lumper.UI/Services/UpdaterService.cs
@@ -1,0 +1,333 @@
+﻿namespace Lumper.UI.Services;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Lumper.Lib.Bsp.IO;
+using Lumper.UI.Views;
+using MsBox.Avalonia;
+using MsBox.Avalonia.Enums;
+using Newtonsoft.Json;
+using NLog;
+using ReactiveUI;
+
+public sealed partial class UpdaterService : ReactiveObject
+{
+    public static UpdaterService Instance { get; } = new();
+
+    private const string ReleasesUrl = "https://api.github.com/repos/momentum-mod/lumper/releases";
+
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+    // Check for updates as soon as service starts
+    // TODO: Track the last update check using Data Persistence, don't call if done recently
+    private UpdaterService() => _ = CheckForUpdates();
+
+    /// <summary>
+    /// Check whether the running executable is up-to-date with the latest release on Github
+    /// <returns>Tuple of whether new release is available and the latest release</returns>
+    /// </summary>
+    public async Task CheckForUpdates()
+    {
+        SemVer currentVersion = GetAssemblyVersion();
+
+        if (currentVersion is { Major: 0, Minor: 0, Patch: 0 })
+        {
+            Logger.Debug("Running a development build, skipping update check");
+            return;
+        }
+
+        GithubRelease latestRelease = await FetchGithubUpdates();
+
+        if (GetAssemblyVersion() >= latestRelease.Version)
+        {
+            Logger.Debug("Current build is up to date");
+            return;
+        }
+
+        if (!await ShowUpdateQuestionDialog(latestRelease))
+            return;
+
+        await Update(latestRelease);
+    }
+
+    /// <summary>
+    /// Get the version embedded in the running Assembly in Semantic Version format (X.Y.Z). This corresponds
+    /// to the Git tag used to build the Github release. For dev builds it's always 0.0.0
+    /// </summary>
+    /// <exception cref="InvalidProgramException"></exception>
+    public static SemVer GetAssemblyVersion() =>
+        SemVer.Parse(
+            Assembly.GetExecutingAssembly().GetName().Version?.ToString()
+                ?? throw new InvalidProgramException("Could not determine version of current assembly!")
+        );
+
+    /// <summary>
+    /// Downloads an update for the program, applies it, and then restarts itself with the new version
+    /// </summary>
+    private static async ValueTask Update(GithubRelease release)
+    {
+        (OSPlatform os, string osPrefix) = GetPlatform();
+        using var zipStream = new MemoryStream();
+        var cts = new CancellationTokenSource();
+        var handler = new IoHandler(cts);
+        var progressWindow = new IoProgressWindow
+        {
+            Title = $"Downloading Lumper {release.Version}",
+            Handler = handler,
+        };
+
+        const int downloadProgressProportion = 80; // 80% of the progress is downloading
+
+        _ = progressWindow.ShowDialog(Program.MainWindow);
+
+        try
+        {
+            using var httpClient = new HttpClient();
+            using HttpResponseMessage response = await httpClient.GetAsync(
+                release.GetDownloadUrl(osPrefix),
+                HttpCompletionOption.ResponseHeadersRead,
+                cts.Token
+            );
+
+            if (response.Content.Headers.ContentLength is null or <= 0)
+                throw new HttpRequestException("Update Failed: Download is empty / has no content length, aborting.");
+
+            Stream downloadStream = await response.Content.ReadAsStreamAsync(cts.Token);
+
+            byte[] buffer = new byte[64 * 1024];
+            int read;
+            int length = (int)response.Content.Headers.ContentLength;
+            int remaining = length;
+
+            while (
+                !handler.Cancelled
+                && (
+                    read = await downloadStream.ReadAsync(
+                        buffer.AsMemory(0, int.Min(buffer.Length, remaining)),
+                        cts.Token
+                    )
+                ) > 0
+            )
+            {
+                float prog = (float)read / length * downloadProgressProportion;
+                handler.UpdateProgress(prog, "Downloading release files");
+                await zipStream.WriteAsync(buffer.AsMemory(0, read), cts.Token);
+                remaining -= read;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to download update!");
+            progressWindow.Close();
+            return;
+        }
+
+        handler.UpdateProgress(0, "Extracting release files...");
+
+        // Zip stream is downloaded into memory, now need to extract it. On both Windows and Linux, we cannot
+        // delete/overwrite the running executable (Lumper.UI(.exe)) but we *can* rename it, extract the new
+        // executable with the original name. Then we just need to spawn a separate progress to clean up the
+        // renamed executable and run the new one.
+        string cwd = AppContext.BaseDirectory;
+        string updaterExecutablePath = Path.Combine(cwd, "Lumper.UI" + (os == OSPlatform.Windows ? ".exe" : ""));
+        string tmpPath = updaterExecutablePath + ".bak";
+
+        try
+        {
+            if (File.Exists(tmpPath))
+                File.Delete(tmpPath);
+
+            File.Move(updaterExecutablePath, tmpPath);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to move updater executable!");
+            progressWindow.Close();
+            return;
+        }
+
+        try
+        {
+            // Using MS ZipArchive because SharpCompress is causing very weird System.Text.Encoding.CodePages errors
+            // during ZipArchive.Open calls in release builds.
+            var zip = new ZipArchive(zipStream);
+            int numEntries = zip.Entries.Count;
+            if (numEntries == 0)
+                throw new InvalidDataException("No entries found in downloaded file");
+
+            foreach (ZipArchiveEntry entry in zip.Entries)
+            {
+                entry.ExtractToFile(Path.Combine(cwd, entry.Name), overwrite: true);
+                float prog = (float)(100 - downloadProgressProportion) / numEntries;
+                handler.UpdateProgress(prog, $"Extracting {entry.Name}");
+                Logger.Info($"Extracted {entry.Name}");
+            }
+        }
+        catch (Exception ex)
+        {
+            File.Move(tmpPath, updaterExecutablePath);
+            Logger.Error(ex, "Failed to extract new version, reverting!");
+            return;
+        }
+        finally
+        {
+            progressWindow.Close();
+        }
+
+        Logger.Info("Update completed, restarting...");
+
+        Process.Start(
+            os == OSPlatform.Windows
+                ? new ProcessStartInfo("cmd.exe", "/c sleep 1 && rm ./Lumper.UI.exe.bak && Lumper.UI.exe")
+                {
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true,
+                    WorkingDirectory = cwd,
+                }
+                : new ProcessStartInfo("sleep 1 && rm ./Lumper.UI.bak && ./Lumper.UI")
+                {
+                    CreateNoWindow = true,
+                    UseShellExecute = true,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true,
+                    WorkingDirectory = cwd,
+                }
+        );
+
+        Environment.Exit(0);
+    }
+
+    private async Task<GithubRelease> FetchGithubUpdates()
+    {
+        using var client = new HttpClient();
+        using var request = new HttpRequestMessage { RequestUri = new Uri(ReleasesUrl), Method = HttpMethod.Get };
+
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("Lumper Auto-Updater"); // Github 401s without this!
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        if (!response.IsSuccessStatusCode)
+            throw new HttpRequestException("Could not connect to Github API", null, response.StatusCode);
+
+        string jsonString = await response.Content.ReadAsStringAsync();
+        List<GithubRelease>? releases = JsonConvert.DeserializeObject<List<GithubRelease>>(jsonString);
+
+        if (releases?[0] is not { } latestRelease)
+            throw new InvalidDataException("Failed to parse version JSON");
+
+        return latestRelease;
+    }
+
+    private async Task<bool> ShowUpdateQuestionDialog(GithubRelease release)
+    {
+        if (
+            !await MessageBoxManager
+                .GetMessageBoxStandard(
+                    "Update Available",
+                    $"An update is available ({release.Version}), do you want to download it and restart?",
+                    ButtonEnum.YesNo
+                )
+                .ShowWindowDialogAsync(Program.MainWindow)
+                .ContinueWith(result => result.Result == ButtonResult.Yes)
+        )
+            return false;
+
+        if (
+            BspService.Instance.IsModified
+            && await MessageBoxManager
+                .GetMessageBoxStandard(
+                    "Unsaved changes",
+                    "You have an open BSP with unsaved changes, do you want to save before updating and restarting?",
+                    ButtonEnum.YesNo
+                )
+                .ShowWindowDialogAsync(Program.MainWindow)
+                .ContinueWith(result => result.Result == ButtonResult.Yes)
+        )
+            await BspService.Instance.Save();
+
+        return true;
+    }
+
+    private static (OSPlatform, string) GetPlatform()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return (OSPlatform.Windows, "win");
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return (OSPlatform.Linux, "linux");
+
+        throw new InvalidProgramException("OS is not supported");
+    }
+
+    public record SemVer(int Major, int Minor, int Patch)
+    {
+        public int Major { get; } = Major;
+        public int Minor { get; } = Minor;
+        public int Patch { get; } = Patch;
+
+        public static bool operator <(SemVer a, SemVer b) =>
+            a.Major < b.Major || a.Minor < b.Minor || a.Patch < b.Patch;
+
+        public static bool operator >(SemVer a, SemVer b) => !(a == b || a < b);
+
+        public static bool operator <=(SemVer a, SemVer b) => !(a > b);
+
+        public static bool operator >=(SemVer a, SemVer b) => !(a < b);
+
+        public override string ToString() => $"{Major}.{Minor}.{Patch}";
+
+        public static SemVer Parse(string s)
+        {
+            // Match pattern of xx.yy.zz
+            Match match = SemVerRegex().Match(s);
+            if (!match.Success)
+                throw new InvalidDataException("Could not parse Major/Minor/Patch version.");
+
+            GroupCollection currentVersion = match.Groups;
+
+            return new SemVer(
+                int.Parse(currentVersion[1].ToString()),
+                int.Parse(currentVersion[2].ToString()),
+                int.Parse(currentVersion[3].ToString())
+            );
+        }
+    }
+
+    [GeneratedRegex(@"^(\d+)\.(\d+)\.(\d+)")]
+    private static partial Regex SemVerRegex();
+
+    // See https://api.github.com/repos/momentum-mod/lumper/releases for the full format
+    public record GithubRelease
+    {
+        [JsonProperty("tag_name")]
+        public required string TagName { get; set; }
+
+        [JsonProperty("assets")]
+        public required GithubAsset[] Assets { get; set; }
+
+        public SemVer Version => SemVer.Parse(TagName);
+
+        public string GetDownloadUrl(string osPrefix) =>
+            Assets.FirstOrDefault(a => a.Name.Contains(osPrefix))?.BrowserDownloadUrl
+            ?? throw new InvalidDataException($"Could not find download link for {osPrefix}");
+    }
+
+    public record GithubAsset
+    {
+        [JsonProperty("browser_download_url")]
+        public required string BrowserDownloadUrl { get; set; }
+
+        [JsonProperty("name")]
+        public required string Name { get; set; }
+    }
+}

--- a/src/Lumper.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Lumper.UI/ViewModels/MainWindowViewModel.cs
@@ -20,6 +20,7 @@ public class MainWindowViewModel : ViewModel
 {
     public static BspService BspService => BspService.Instance;
     public static PageService PageService => PageService.Instance;
+    public static UpdaterService UpdaterService => UpdaterService.Instance;
 
     public LogViewerViewModel LogViewer { get; set; } = new();
 

--- a/src/Lumper.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Lumper.UI/ViewModels/MainWindowViewModel.cs
@@ -62,11 +62,11 @@ public class MainWindowViewModel : ViewModel
                 Width = 400,
                 InputParams = new InputParams(),
                 WindowStartupLocation = WindowStartupLocation.CenterOwner,
-                ButtonDefinitions = new[]
-                {
+                ButtonDefinitions =
+                [
                     new ButtonDefinition { Name = "Load", IsDefault = true },
                     new ButtonDefinition { Name = "Cancel", IsCancel = true },
-                },
+                ],
             }
         );
 
@@ -117,7 +117,7 @@ public class MainWindowViewModel : ViewModel
         {
             Title = "Export JSON Summary",
             DefaultExtension = ".json",
-            FileTypeChoices = new[] { new FilePickerFileType("JSON File") { Patterns = ["*.json"] } },
+            FileTypeChoices = [new FilePickerFileType("JSON File") { Patterns = ["*.json"] }],
         };
 
         IStorageFile? result = await Program.MainWindow.StorageProvider.SaveFilePickerAsync(dialog);
@@ -168,15 +168,15 @@ public class MainWindowViewModel : ViewModel
 
     private static FilePickerFileType[] GenerateBspFileFilter() =>
         [
-            new FilePickerFileType("BSP Files")
+            new("BSP Files")
             {
-                Patterns = new[] { "*.bsp" },
+                Patterns = ["*.bsp"],
                 // MIME references from:
                 // https://www.wikidata.org/wiki/Q105858735
                 // https://www.wikidata.org/wiki/Q105859836
                 // https://www.wikidata.org/wiki/Q2701652
-                MimeTypes = new[] { "application/octet-stream", "model/vnd.valve.source.compiled-map" },
+                MimeTypes = ["application/octet-stream", "model/vnd.valve.source.compiled-map"],
             },
-            new FilePickerFileType("All Files") { Patterns = new[] { "*" } },
+            new("All Files") { Patterns = ["*"] },
         ];
 }

--- a/src/Lumper.UI/ViewModels/Pages/EntityEditor/EntityEditorViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/EntityEditor/EntityEditorViewModel.cs
@@ -110,7 +110,7 @@ public sealed class EntityEditorViewModel : ViewModelWithView<EntityEditorViewMo
         if (model is null || model == SelectedTab?.Entity)
             return;
 
-        if (SelectedTab is not null && SelectedTab.Entity.IsModified == false && SelectedTab.IsPinned == false)
+        if (SelectedTab is not null && !SelectedTab.Entity.IsModified && !SelectedTab.IsPinned)
             Tabs.Remove(SelectedTab);
 
         EntityEditorTabViewModel? newTab = Tabs.FirstOrDefault(x => x.Entity == model);
@@ -125,7 +125,7 @@ public sealed class EntityEditorViewModel : ViewModelWithView<EntityEditorViewMo
 
     public void TogglePinnedTab(EntityEditorTabViewModel tab)
     {
-        if (tab.IsPinned == false && tab != SelectedTab)
+        if (!tab.IsPinned && tab != SelectedTab)
             Tabs.Remove(tab);
     }
 

--- a/src/Lumper.UI/ViewModels/Pages/Jobs/JobsViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/Jobs/JobsViewModel.cs
@@ -171,10 +171,7 @@ public class JobsViewModel : ViewModelWithView<JobsViewModel, JobsView>
 
     public async Task ShowLoadJobsFileDialog()
     {
-        if (Program.Desktop.MainWindow is null)
-            return;
-
-        IReadOnlyList<IStorageFile> result = await Program.Desktop.MainWindow.StorageProvider.OpenFilePickerAsync(
+        IReadOnlyList<IStorageFile> result = await Program.MainWindow.StorageProvider.OpenFilePickerAsync(
             new FilePickerOpenOptions
             {
                 AllowMultiple = false,
@@ -191,10 +188,7 @@ public class JobsViewModel : ViewModelWithView<JobsViewModel, JobsView>
 
     public async Task ShowSaveJobsFileDialog()
     {
-        if (Program.Desktop.MainWindow is null)
-            return;
-
-        IStorageFile? result = await Program.Desktop.MainWindow.StorageProvider.SaveFilePickerAsync(
+        IStorageFile? result = await Program.MainWindow.StorageProvider.SaveFilePickerAsync(
             new FilePickerSaveOptions { Title = "Save Jobs File", FileTypeChoices = GenerateJsonFileFilter() }
         );
 

--- a/src/Lumper.UI/ViewModels/Pages/Jobs/RunExternalToolJobViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/Jobs/RunExternalToolJobViewModel.cs
@@ -68,10 +68,7 @@ public class RunExternalToolJobViewModel : JobViewModel
 
     public async Task ShowFilePickerDialog()
     {
-        if (Program.Desktop.MainWindow is null)
-            return;
-
-        IReadOnlyList<IStorageFile> result = await Program.Desktop.MainWindow.StorageProvider.OpenFilePickerAsync(
+        IReadOnlyList<IStorageFile> result = await Program.MainWindow.StorageProvider.OpenFilePickerAsync(
             new FilePickerOpenOptions { Title = "Pick Executable", AllowMultiple = false }
         );
 
@@ -79,12 +76,9 @@ public class RunExternalToolJobViewModel : JobViewModel
             Path = result[0].Path.LocalPath;
     }
 
-    public async void ShowFolderPickerDialog()
+    public async Task ShowFolderPickerDialog()
     {
-        if (Program.Desktop.MainWindow is null)
-            return;
-
-        IReadOnlyList<IStorageFolder> result = await Program.Desktop.MainWindow.StorageProvider.OpenFolderPickerAsync(
+        IReadOnlyList<IStorageFolder> result = await Program.MainWindow.StorageProvider.OpenFolderPickerAsync(
             new FolderPickerOpenOptions { Title = "Pick Working Directory" }
         );
 

--- a/src/Lumper.UI/ViewModels/Pages/Jobs/StripperJobViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/Jobs/StripperJobViewModel.cs
@@ -30,10 +30,7 @@ public class StripperJobViewModel : JobViewModel
 
     public async Task ShowFilePickerDialog()
     {
-        if (Program.Desktop.MainWindow is null)
-            return;
-
-        IReadOnlyList<IStorageFile> result = await Program.Desktop.MainWindow.StorageProvider.OpenFilePickerAsync(
+        IReadOnlyList<IStorageFile> result = await Program.MainWindow.StorageProvider.OpenFilePickerAsync(
             GenerateFilePickerOptions()
         );
 
@@ -48,6 +45,6 @@ public class StripperJobViewModel : JobViewModel
         {
             Title = "Pick Stripper Config",
             AllowMultiple = false,
-            FileTypeFilter = [new FilePickerFileType("Stripper Config") { Patterns = new[] { "*.cfg" } }],
+            FileTypeFilter = [new FilePickerFileType("Stripper Config") { Patterns = ["*.cfg"] }],
         };
 }

--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
@@ -462,11 +462,11 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
                 InputParams = new InputParams { Label = inputLabel, DefaultValue = defaultInput },
                 Width = 400,
                 WindowStartupLocation = WindowStartupLocation.CenterOwner,
-                ButtonDefinitions = new[]
-                {
+                ButtonDefinitions =
+                [
                     new ButtonDefinition { Name = buttonLabel, IsDefault = true },
                     new ButtonDefinition { Name = "Cancel", IsCancel = true },
-                },
+                ],
             }
         );
 

--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
@@ -194,7 +194,7 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
                         "Do you want to update instances of this path in other parts of the BSP?",
                         ButtonEnum.YesNo
                     )
-                    .ShowWindowDialogAsync(Program.Desktop.MainWindow);
+                    .ShowWindowDialogAsync(Program.MainWindow);
 
                 moveReferences = result == ButtonResult.Yes;
                 queriedUser = true;
@@ -470,15 +470,11 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
             }
         );
 
-    private static Task<string> ShowMessageBox(IMsBox<string> msBox) =>
-        msBox.ShowWindowDialogAsync(Program.Desktop.MainWindow);
+    private static Task<string> ShowMessageBox(IMsBox<string> msBox) => msBox.ShowWindowDialogAsync(Program.MainWindow);
 
     private static async ValueTask<IStorageFolder?> PickFolder(string title = "Pick folder")
     {
-        if (Program.Desktop.MainWindow is null)
-            return null;
-
-        IReadOnlyList<IStorageFolder> result = await Program.Desktop.MainWindow.StorageProvider.OpenFolderPickerAsync(
+        IReadOnlyList<IStorageFolder> result = await Program.MainWindow.StorageProvider.OpenFolderPickerAsync(
             new FolderPickerOpenOptions { Title = title }
         );
 
@@ -488,13 +484,8 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
         return result[0];
     }
 
-    private static async ValueTask<IReadOnlyList<IStorageFile>?> PickFiles(string title = "Pick file(s)")
-    {
-        if (Program.Desktop.MainWindow is null)
-            return null;
-
-        return await Program.Desktop.MainWindow.StorageProvider.OpenFilePickerAsync(
+    private static Task<IReadOnlyList<IStorageFile>> PickFiles(string title = "Pick file(s)") =>
+        Program.MainWindow.StorageProvider.OpenFilePickerAsync(
             new FilePickerOpenOptions { Title = title, AllowMultiple = true }
         );
-    }
 }

--- a/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryTextViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryTextViewModel.cs
@@ -59,7 +59,7 @@ public class PakfileEntryTextViewModel : PakfileEntryViewModel
             DataStream.Seek(0, SeekOrigin.Begin);
             await DataStream.CopyToAsync(fileStream);
             fileStream.Flush();
-            await Program.Desktop.MainWindow!.Launcher.LaunchUriAsync(new Uri(fileName));
+            await Program.MainWindow.Launcher.LaunchUriAsync(new Uri(fileName));
         }
         catch (IOException ex)
         {

--- a/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryVtfViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryVtfViewModel.cs
@@ -109,10 +109,10 @@ public class PakfileEntryVtfViewModel : PakfileEntryViewModel
 
     public async Task SetImage(bool createNew)
     {
-        if (VtfFile is null || Program.Desktop.MainWindow is null)
+        if (VtfFile is null)
             return;
 
-        IReadOnlyList<IStorageFile> result = await Program.Desktop.MainWindow.StorageProvider.OpenFilePickerAsync(
+        IReadOnlyList<IStorageFile> result = await Program.MainWindow.StorageProvider.OpenFilePickerAsync(
             new FilePickerOpenOptions
             {
                 AllowMultiple = false,

--- a/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryVtfViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryVtfViewModel.cs
@@ -172,7 +172,7 @@ public class PakfileEntryVtfViewModel : PakfileEntryViewModel
 
     private static FilePickerFileType[] GenerateImageFileFilter() =>
         [
-            new FilePickerFileType("Image files") { Patterns = new[] { "*.bmp", "*.jpeg", "*.jpg", "*.png" } },
-            new FilePickerFileType("All files") { Patterns = new[] { "*" } },
+            new FilePickerFileType("Image files") { Patterns = ["*.bmp", "*.jpeg", "*.jpg", "*.png"] },
+            new FilePickerFileType("All files") { Patterns = ["*"] },
         ];
 }

--- a/src/Lumper.UI/ViewModels/Shared/Vtf/VtfFileViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Vtf/VtfFileViewModel.cs
@@ -279,7 +279,7 @@ public class VtfFileViewModel(PakfileEntry pakfileEntry) : ViewModel
     {
         private static readonly ConcurrentQueue<(Func<object>, CancellationTokenSource?)> Queue = new();
         private static readonly Subject<(Func<object>, object?)> Output = new();
-        private static readonly object Lock = new();
+        private static readonly Lock Lock = new();
         private static bool _isRunning;
 
         public static Task Run(Action fn) => Run(fn, null);

--- a/src/Lumper.UI/Views/MainWindow.axaml
+++ b/src/Lumper.UI/Views/MainWindow.axaml
@@ -89,6 +89,10 @@
               <MenuItem Header="_Jobs" Command="{Binding PageService.ViewPage}"
                         CommandParameter="{x:Static service:Page.Jobs}" InputGesture="Ctrl+D5" />
             </MenuItem>
+            <MenuItem Header="_About">
+              <MenuItem Header="_Check for updates" Command="{Binding UpdaterService.CheckForUpdates}"/>
+              <!-- TODO: About dialog! -->
+            </MenuItem>
           </Menu>
         </StackPanel>
       </DockPanel>


### PR DESCRIPTION
Piggy-backing off https://github.com/momentum-mod/lumper/pull/50 to do auto-updating using much fewer shell commands.

We download the release zip into memory rather than disk, rename the *running executable* (Lumper.UI.exe), which both Windows and Linux allow, extract the release zip into the same directory as the running executable, then start a shell command to remove the renamed executable and launch the new one, then exit. No `rm -rf` required, less OS-specific code.