### PR TITLE
Fix UI exception when loading BSP passed via CLI arg

### DIFF
--- a/src/Lumper.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Lumper.UI/ViewModels/MainWindowViewModel.cs
@@ -27,12 +27,13 @@ public class MainWindowViewModel : ViewModel
 
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-    public MainWindowViewModel()
+    public MainWindowViewModel() =>
+        Program.Desktop.Startup += (_, _) => Program.MainWindow.Opened += (_, _) => OnMainWindowOpened();
+
+    private void OnMainWindowOpened()
     {
-        if (Program.Desktop.Args is { Length: 1 })
-        {
-            Observable.Start(() => BspService.Instance.Load(Program.Desktop.Args[0]), RxApp.MainThreadScheduler);
-        }
+        if (Program.Desktop.Args is [{ } bspFile])
+            Observable.Start(() => BspService.Instance.Load(bspFile), RxApp.MainThreadScheduler);
     }
 
     public async Task OpenCommand()


### PR DESCRIPTION
My `refactor(ui): Program.MainWindow property to avoid annoying null checks` commit actually does throw in *one* place, because if you provide a BSP file via 1st argument place we start loading it before the main window is finished loading.

However, this really isn't behaviour we want anyway. For a large map this would result in no loading bar showing for the duration of the map load, which is typically much longer than the main window startup.