### PR TITLE
Fix error saving static prop lumps if sprp gamelump empty

### DIFF
--- a/src/Lumper.Lib/BSP/IO/GameLumpWriter.cs
+++ b/src/Lumper.Lib/BSP/IO/GameLumpWriter.cs
@@ -77,8 +77,9 @@ public sealed class GameLumpWriter(GameLump gameLump, Stream output, IoHandler? 
             LumpHeaderInfo newHeaderInfo = Write(lump);
             HeaderInfo.Add((lump, newHeaderInfo));
 
-            // TODO: meh
-            lump.Version = lump is Sprp sprp ? (ushort)sprp.StaticProps.GetVersion() : (ushort)lump.Version;
+            lump.Version = lump is Sprp sprp
+                ? (ushort)(sprp.StaticProps?.GetVersion() ?? (ushort)StaticPropVersion.Unknown)
+                : (ushort)lump.Version;
 
             headers.Add(new GameLumpHeader(newHeaderInfo, (ushort)lump.Version, (int)key));
 

--- a/src/Lumper.Lib/BSP/Lumps/GameLumps/Sprp.cs
+++ b/src/Lumper.Lib/BSP/Lumps/GameLumps/Sprp.cs
@@ -8,9 +8,10 @@ using NLog;
 
 public class Sprp(BspFile parent) : ManagedLump<GameLumpType>(parent)
 {
-    public StaticPropDictLump StaticPropsDict { get; set; } = null!;
-    public StaticPropLeafLump StaticPropsLeaf { get; set; } = null!;
-    public StaticPropLump StaticProps { get; set; } = null!;
+    // All are null iff Sprp is empty when reading i.e. header says length == 0
+    public StaticPropDictLump? StaticPropsDict { get; set; }
+    public StaticPropLeafLump? StaticPropsLeaf { get; set; }
+    public StaticPropLump? StaticProps { get; set; }
 
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
@@ -60,15 +61,27 @@ public class Sprp(BspFile parent) : ManagedLump<GameLumpType>(parent)
     {
         var w = new BinaryWriter(stream);
 
-        w.Write(StaticPropsDict.Data.Count);
-        StaticPropsDict.Write(w.BaseStream);
+        if (StaticPropsDict is not null)
+        {
+            w.Write(StaticPropsDict.Data.Count);
+            StaticPropsDict.Write(w.BaseStream);
+        }
 
-        w.Write(StaticPropsLeaf.Data.Count);
-        StaticPropsLeaf.Write(w.BaseStream);
+        if (StaticPropsLeaf is not null)
+        {
+            w.Write(StaticPropsLeaf.Data.Count);
+            StaticPropsLeaf.Write(w.BaseStream);
+        }
 
-        w.Write(StaticProps.Data.Count);
-        StaticProps.Write(w.BaseStream);
+        if (StaticProps is not null)
+        {
+            w.Write(StaticProps.Data.Count);
+            StaticProps.Write(w.BaseStream);
+        }
     }
 
-    public override bool Empty => StaticProps.Empty && StaticPropsDict.Empty && StaticPropsLeaf.Empty;
+    public override bool Empty =>
+        (StaticProps is null || StaticProps.Empty)
+        && (StaticPropsDict is null || StaticPropsDict.Empty)
+        && (StaticPropsLeaf is null || StaticPropsLeaf.Empty);
 }


### PR DESCRIPTION
Lots of properties of various lumps we can safely mark non-null even when not inited in ctor since we only consider the lump "valid" only its `Read` method has been called.

For the `sprp` lump however the static prop lump it stores *can* be null after being read, if the entire `sprp` lump was 0 length. Therefore we need to handle null cases, otherwise can throw when writing.