### PR TITLE
Fix very small lumps not being compressed properly 

### DIFF
--- a/src/Lumper.Lib/BSP/IO/BspFileWriter.cs
+++ b/src/Lumper.Lib/BSP/IO/BspFileWriter.cs
@@ -50,7 +50,7 @@ public sealed class BspFileWriter(BspFile file, Stream output, IoHandler? handle
     {
         Seek(0, SeekOrigin.Begin);
 
-        Write(Encoding.ASCII.GetBytes("VBSP"));
+        Write("VBSP"u8);
         Write(_bsp.Version);
 
         foreach (BspLumpHeader? lump in LumpHeaders.OrderBy(x => x.Key).Select(x => x.Value))

--- a/src/Lumper.Lib/BSP/IO/LumpWriter.cs
+++ b/src/Lumper.Lib/BSP/IO/LumpWriter.cs
@@ -124,8 +124,7 @@ public abstract class LumpWriter(Stream output) : BinaryWriter(output, Encoding.
         long compressedLength = mem.Length;
 
         var writer = new BinaryWriter(mem);
-        const int lzmaId = ('A' << 24) | ('M' << 16) | ('Z' << 8) | 'L';
-        writer.Write(lzmaId);
+        writer.Write("LZMA"u8);
         writer.Write((int)uncompressedStream.Length);
         writer.Write((int)mem.Length - headerSize);
         writer.Write(lzmaStream.Properties);


### PR DESCRIPTION
Closes #74

We were writing out lumps < 22 bytes large as uncompressed since the LZMA header actually causes the lump to get larger. That causes the BSP to fail our compression checks in the website repo.

`bspzip` doesn't seem to have our optimization, and it's such an insignificant amount of data anyway, no problem always writing the header.