### PR TITLE
Fix NUL chars being displayed in text editor

### DIFF
--- a/src/Lumper.Lib/BSP/Struct/PakFileEntry.cs
+++ b/src/Lumper.Lib/BSP/Struct/PakFileEntry.cs
@@ -74,7 +74,7 @@ public sealed class PakfileEntry
         {
             lock (ZipAccessLock)
             {
-                using var mem = new MemoryStream(); // Note MemoryStream disposal doesn't delete underlying buffer
+                using var mem = new MemoryStream((int)ZipEntry!.Size); // Note MemoryStream disposal doesn't delete underlying buffer
                 using Stream zipStream = ZipEntry!.OpenEntryStream();
                 zipStream.CopyTo(mem);
                 _buffer = mem.GetBuffer();


### PR DESCRIPTION
Closes https://github.com/momentum-mod/lumper/issues/88
Rebased on top of #87, fix here is just the last commit.

PakfileEntry buffer is derived from a resizable MemoryStream buffer, so gets padded up. For text data, this results in a bunch of a NULs. Buffer is readonly unless replaced entirely, so we can just limit it to the size of the uncompressed zip data.