### PR TITLE
Fix texture browser performance issues

### DIFF
--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
@@ -389,7 +389,7 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
 
                 Directory.CreateDirectory(dirName);
                 await using var fstream = new FileStream(fi.FullName, FileMode.Create);
-                fstream.Write(entry.Data);
+                fstream.Write(entry.GetData());
             }
 
             Logger.Info($"Wrote pakfile contents to {rootPath}");
@@ -437,7 +437,7 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
 
                 Directory.CreateDirectory(dirName);
                 await using var fstream = new FileStream(fi.FullName, FileMode.Create);
-                fstream.Write(entry.Data);
+                fstream.Write(entry.GetData());
 
                 Logger.Info($"Exported {entry.Key} to {fi.FullName}");
             }

--- a/src/Lumper.UI/ViewModels/Pages/VtfBrowser/VtfBrowserViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/VtfBrowser/VtfBrowserViewModel.cs
@@ -32,6 +32,7 @@ public partial class VtfBrowserViewModel : ViewModelWithView<VtfBrowserViewModel
         // Generate observable catch of just VTFs, loading them as they're added
         IObservableCache<PakfileEntryVtfViewModel, string> vtfs = BspService
             .Instance.WhenAnyValue(x => x.PakfileLumpViewModel)
+            .ObserveOn(RxApp.TaskpoolScheduler)
             .Where(x => x is not null)
             .Select(x =>
                 x!

--- a/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryTextViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryTextViewModel.cs
@@ -36,7 +36,7 @@ public class PakfileEntryTextViewModel : PakfileEntryViewModel
     {
         try
         {
-            Content = Encoding.ASCII.GetString(Data);
+            Content = Encoding.ASCII.GetString(GetData());
         }
         catch
         {
@@ -54,7 +54,7 @@ public class PakfileEntryTextViewModel : PakfileEntryViewModel
         try
         {
             await using var fileStream = new FileStream(fileName, FileMode.CreateNew);
-            fileStream.Write(Data);
+            fileStream.Write(GetData());
             fileStream.Flush();
             await Program.MainWindow.Launcher.LaunchUriAsync(new Uri(fileName));
         }

--- a/src/Lumper.UI/ViewModels/Shared/Vtf/VtfFileViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Vtf/VtfFileViewModel.cs
@@ -192,7 +192,7 @@ public class VtfFileViewModel(PakfileEntryVtfViewModel pakfileEntry) : ViewModel
         }
 
         // Copy (ToArray) is required since VTFLib needs a byte[] which is inherently mutable.
-        byte[] vtfBuffer = pakfileEntry.Data.ToArray();
+        byte[] vtfBuffer = pakfileEntry.GetData().ToArray();
 
         VTFFile.CreateImage(ref _imageIndex);
         VTFFile.BindImage(_imageIndex);

--- a/src/Lumper.UI/Views/Pages/VtfBrowser/VtfBrowserView.axaml
+++ b/src/Lumper.UI/Views/Pages/VtfBrowser/VtfBrowserView.axaml
@@ -56,7 +56,8 @@
                                               Margin="4 3 6 4" HorizontalAlignment="Center" VerticalAlignment="Center" />
                 </StackPanel>
                 <StackPanel
-                  MaxWidth="{Binding ViewModel.StateService.VtfBrowserDimensions, RelativeSource={RelativeSource AncestorType=views:VtfBrowserView}, FallbackValue=192}">
+                    Height="{Binding ViewModel.StateService.VtfBrowserDimensions, RelativeSource={RelativeSource AncestorType=views:VtfBrowserView}, FallbackValue=192}"
+                    Width="{Binding ViewModel.StateService.VtfBrowserDimensions, RelativeSource={RelativeSource AncestorType=views:VtfBrowserView}, FallbackValue=192}">
                   <Image
                     Height="{Binding ViewModel.StateService.VtfBrowserDimensions, RelativeSource={RelativeSource AncestorType=views:VtfBrowserView}, FallbackValue=192}"
                     Width="{Binding ViewModel.StateService.VtfBrowserDimensions, RelativeSource={RelativeSource AncestorType=views:VtfBrowserView}, FallbackValue=192}"


### PR DESCRIPTION
Noticed major performance issues when loading the texture browser page for maps with a lot of textures. Had to rework pakfile data loading a little more, see commit comments. Bottleneck is now VTFLib bitmap conversion and Avalonia rendering.