### PR TITLE
Improve Log Viewer performance

### DIFF
--- a/src/Lumper.UI/Views/LogViewer/LogViewerView.axaml
+++ b/src/Lumper.UI/Views/LogViewer/LogViewerView.axaml
@@ -12,8 +12,14 @@
     <ScrollViewer Grid.Column="0" Grid.Row="0" Grid.RowSpan="4" Name="ScrollViewer" VerticalAlignment="Stretch"
                   VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Auto" Background="#55000000"
                   MaxHeight="Infinity">
-      <SelectableTextBlock Name="Logs" FontSize="14" FontFamily="{StaticResource Monospace}" ClipToBounds="True"
-                           VerticalAlignment="Stretch" Padding="16" />
+      <ItemsControl Name="LogLines" Padding="4">
+        <ItemsControl.Styles>
+          <Style Selector="SelectableTextBlock">
+            <Setter Property="FontFamily" Value="{StaticResource Monospace}" />
+            <Setter Property="FontSize" Value="14" />
+          </Style>
+        </ItemsControl.Styles>
+      </ItemsControl>
     </ScrollViewer>
     <Button Click="ScrollToBottom" Margin="4" Grid.Column="1" Grid.Row="0" Padding="0"
             ToolTip.Tip="Scroll to Bottom">


### PR DESCRIPTION
Was using a single massive `SelectableTextBlock` for this so that people could copy multiple lines at once, but the performance was horrifically slow. Couldn't find a way to keep the multiple line selection, more important to fix the perf degradation. Errors and stack traces are still single `SelectableTextBlock`s so users shouldn't have a problem copying those if needed.

Also, if really necessary, NLog stores all log output to file anyway.