### PR TITLE
Better EntityIO matching in Entity Editor

### DIFF
--- a/src/Lumper.Lib/BSP/Struct/EntityIO.cs
+++ b/src/Lumper.Lib/BSP/Struct/EntityIO.cs
@@ -89,8 +89,13 @@ public partial class EntityIo : ICloneable
         }
     }
 
+    // csharpier-ignore
     public override string ToString() =>
-        TargetEntityName + _separator + Input + _separator + Parameter + _separator + Delay + _separator + TimesToFire;
+          TargetEntityName + _separator
+        + Input + _separator
+        + Parameter + _separator
+        + Delay?.ToString(CultureInfo.InvariantCulture) + _separator
+        + TimesToFire?.ToString(CultureInfo.InvariantCulture);
 
     public object Clone() => MemberwiseClone();
 

--- a/src/Lumper.Lib/BSP/Struct/EntityIO.cs
+++ b/src/Lumper.Lib/BSP/Struct/EntityIO.cs
@@ -100,6 +100,6 @@ public partial class EntityIo : ICloneable
     public object Clone() => MemberwiseClone();
 
     // Match string,string,string,number,number where numbers can be decimals, negative, -.xxx
-    [GeneratedRegex(@"^[^,]*," + @"[^,]*," + @"[^,]*" + @"(,(-?\d*\.?\d+)?){2}$")]
+    [GeneratedRegex(@"^[^,]*,[^,]*,[^,]*(,(-?\d*\.?\d+)?){2}$")]
     private static partial Regex EntityIoRegex();
 }

--- a/src/Lumper.UI/ViewModels/Pages/EntityEditor/EntityEditorFiltersViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/EntityEditor/EntityEditorFiltersViewModel.cs
@@ -53,7 +53,7 @@ public class EntityEditorFilters : ReactiveObject
         if (string.IsNullOrWhiteSpace(filter))
             return false;
 
-        var split = filter.Split(',').Select(s => s.Trim()).ToList();
+        var split = filter.Split('|').Select(s => s.Trim()).ToList();
         if (split.Count == 0)
             return false;
 

--- a/src/Lumper.UI/ViewModels/Pages/EntityEditor/EntityEditorViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/EntityEditor/EntityEditorViewModel.cs
@@ -190,6 +190,9 @@ public sealed class EntityEditorViewModel : ViewModelWithView<EntityEditorViewMo
             out List<string>? exVals
         );
 
+        // Using the wildcard wrapping behaviour for everything here (e.g. BCD matches ABCDE),
+        // usage is very unintuitive without wrapping enabled and really don't want to have
+        // a separate checkbox for it.
         if (hasKeys || hasVals)
         {
             filtered = true;
@@ -197,10 +200,10 @@ public sealed class EntityEditorViewModel : ViewModelWithView<EntityEditorViewMo
             {
                 output = output.Where(vm =>
                     vm.Properties.Any(prop =>
-                        (inKeys!.Count == 0 || inKeys.Any(key => prop.MatchKey(key)))
-                        && !exKeys!.Any(key => prop.MatchKey(key))
-                        && (inVals!.Count == 0 || inVals.Any(val => prop.MatchValue(val)))
-                        && !exVals!.Any(val => prop.MatchValue(val))
+                        (inKeys!.Count == 0 || inKeys.Any(key => prop.MatchKey(key, true)))
+                        && !exKeys!.Any(key => prop.MatchKey(key, true))
+                        && (inVals!.Count == 0 || inVals.Any(val => prop.MatchValue(val, true)))
+                        && !exVals!.Any(val => prop.MatchValue(val, true))
                     )
                 );
             }
@@ -208,8 +211,8 @@ public sealed class EntityEditorViewModel : ViewModelWithView<EntityEditorViewMo
             {
                 output = output.Where(vm =>
                     vm.Properties.Any(prop =>
-                        (inKeys!.Count == 0 || inKeys.Any(key => prop.MatchKey(key)))
-                        && !exKeys!.Any(key => prop.MatchKey(key))
+                        (inKeys!.Count == 0 || inKeys.Any(key => prop.MatchKey(key, true)))
+                        && !exKeys!.Any(key => prop.MatchKey(key, true))
                     )
                 );
             }
@@ -217,8 +220,8 @@ public sealed class EntityEditorViewModel : ViewModelWithView<EntityEditorViewMo
             {
                 output = output.Where(vm =>
                     vm.Properties.Any(prop =>
-                        (inVals!.Count == 0 || inVals.Any(val => prop.MatchValue(val)))
-                        && !exVals!.Any(val => prop.MatchValue(val))
+                        (inVals!.Count == 0 || inVals.Any(val => prop.MatchValue(val, true)))
+                        && !exVals!.Any(val => prop.MatchValue(val, true))
                     )
                 );
             }

--- a/src/Lumper.UI/ViewModels/Shared/Entity/EntityPropertyViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Entity/EntityPropertyViewModel.cs
@@ -1,5 +1,6 @@
 namespace Lumper.UI.ViewModels.Shared.Entity;
 
+using System.Globalization;
 using Lumper.Lib.Bsp.Struct;
 using Lumper.Lib.ExtensionMethods;
 
@@ -127,11 +128,10 @@ public class EntityPropertyIoViewModel(Entity.EntityProperty<EntityIo> entityPro
         && other.Delay == Delay
         && other.TimesToFire == TimesToFire;
 
-    // csharpier-ignore
-    public override bool MatchValue(string expr, bool trailingWildcard) =>
-        (TargetEntityName?.MatchesSimpleExpression(expr, trailingWildcard) ?? false) ||
-        (Input?.MatchesSimpleExpression(expr, trailingWildcard) ?? false) ||
-        (Parameter?.MatchesSimpleExpression(expr, trailingWildcard) ?? false) ||
-        (Delay?.ToString(CultureInfo.InvariantCulture).MatchesSimpleExpression(expr, trailingWildcard) ?? false) ||
-        (TimesToFire?.ToString(CultureInfo.InvariantCulture).MatchesSimpleExpression(expr, trailingWildcard) ?? false);
+    public override bool MatchValue(string expr, bool wildcardWrapping) =>
+        // Match against both comma and space separated values
+        string.Create(CultureInfo.InvariantCulture, $"{TargetEntityName} {Input} {Parameter} {Delay} {TimesToFire}")
+            .MatchesSimpleExpression(expr, wildcardWrapping)
+        || string.Create(CultureInfo.InvariantCulture, $"{TargetEntityName},{Input},{Parameter},{Delay},{TimesToFire}")
+            .MatchesSimpleExpression(expr, wildcardWrapping);
 }

--- a/src/Lumper.UI/ViewModels/Shared/Entity/EntityPropertyViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Entity/EntityPropertyViewModel.cs
@@ -1,6 +1,5 @@
 namespace Lumper.UI.ViewModels.Shared.Entity;
 
-using System.Globalization;
 using Lumper.Lib.Bsp.Struct;
 using Lumper.Lib.ExtensionMethods;
 
@@ -29,10 +28,9 @@ public abstract class EntityPropertyViewModel(Entity.EntityProperty entityProper
 
     public override void UpdateModel() => EntityProperty.Key = Key;
 
-    public bool MatchKey(string expr, bool wildcardWrapping = false) =>
-        Key.MatchesSimpleExpression(expr, wildcardWrapping);
+    public bool MatchKey(string expr, bool wildcardWrapping) => Key.MatchesSimpleExpression(expr, wildcardWrapping);
 
-    public abstract bool MatchValue(string expr, bool trailingWildcard = false);
+    public abstract bool MatchValue(string expr, bool wildcardWrapping);
 
     public void Delete() => ((EntityViewModel)Parent).DeleteProperty(this);
 }
@@ -60,8 +58,8 @@ public class EntityPropertyStringViewModel(Entity.EntityProperty<string> entityP
         entityProperty.Value = Value;
     }
 
-    public override bool MatchValue(string expr, bool trailingWildcard) =>
-        Value?.MatchesSimpleExpression(expr, trailingWildcard) ?? false;
+    public override bool MatchValue(string expr, bool wildcardWrapping) =>
+        Value?.MatchesSimpleExpression(expr, wildcardWrapping) ?? false;
 }
 
 public class EntityPropertyIoViewModel(Entity.EntityProperty<EntityIo> entityProperty, BspNode bspNode)

--- a/src/Lumper.UI/Views/Pages/EntityEditor/EntityEditorView.axaml
+++ b/src/Lumper.UI/Views/Pages/EntityEditor/EntityEditorView.axaml
@@ -24,13 +24,13 @@
           <StackPanel>
             <TextBlock FontSize="18" FontWeight="Medium">Entity Type / Key / Value</TextBlock>
             <TextBlock LineHeight="24">
-              Multiple inputs can be provided at once separated by commas, and entities/properties will match if any
-              value matches. Use <Run FontFamily="{StaticResource Monospace}">-</Run> to exclude on the front of a value
-              to exclude that value.
+              Multiple inputs can be provided at once separated by <Run FontFamily="{StaticResource Monospace}">|</Run>,
+              and entities/properties will match if any value matches.
+              Use <Run FontFamily="{StaticResource Monospace}">-</Run> to exclude on the front of a value to exclude that value.
               <LineBreak />
               <Run FontStyle="Italic" FontWeight="Medium">Example</Run>
               <LineBreak />
-              <Run FontFamily="{StaticResource Monospace}">light, -light_spot</Run> entity type will match any entity
+              <Run FontFamily="{StaticResource Monospace}">light|-light_spot</Run> entity type will match any entity
               with <Run FontFamily="{StaticResource Monospace}">light</Run> in the classname, but not
               <Run FontFamily="{StaticResource Monospace}">light_spot</Run>.
             </TextBlock>


### PR DESCRIPTION
Previously something like `!activator AddOutput` would fail to match since it would compare against TargetEntityName and Input separately.

Requested in https://github.com/momentum-mod/lumper/issues/113#issuecomment-2692478278