### PR TITLE
Push viewmodel changes to models before running jobs

### DIFF
--- a/src/Lumper.UI/Services/BspService.cs
+++ b/src/Lumper.UI/Services/BspService.cs
@@ -310,8 +310,8 @@ public sealed class BspService : ReactiveObject, IDisposable
             return false;
 
         IsLoading = true;
-        foreach (ILumpViewModel? vm in Lumps)
-            vm?.UpdateModel(); // Null propagation means we do nothing for unloaded lumps VMs
+
+        UpdateModels();
 
         IoProgressWindow? progressWindow = null;
         try
@@ -430,6 +430,15 @@ public sealed class BspService : ReactiveObject, IDisposable
             return;
 
         IsModified = true;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    public void UpdateModels()
+    {
+        foreach (ILumpViewModel? vm in Lumps)
+            vm?.UpdateModel(); // Null propagation means we do nothing for unloaded lumps VMs
     }
 
     public void ResetLumpViewModels()

--- a/src/Lumper.UI/ViewModels/Pages/Jobs/JobViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/Jobs/JobViewModel.cs
@@ -35,6 +35,8 @@ public abstract class JobViewModel : ViewModel
     {
         Status = JobStatus.Running;
 
+        Prepare();
+
         bool status = Job.Run(bsp);
 
         if (status)
@@ -49,6 +51,8 @@ public abstract class JobViewModel : ViewModel
             return false;
         }
     }
+
+    protected virtual void Prepare() { }
 
     protected virtual void OnSuccess() { }
 

--- a/src/Lumper.UI/ViewModels/Pages/Jobs/RunExternalToolJobViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/Jobs/RunExternalToolJobViewModel.cs
@@ -59,6 +59,8 @@ public class RunExternalToolJobViewModel : JobViewModel
             .BindTo(this, x => x.Job.WritesToInputFile);
     }
 
+    protected override void Prepare() => BspService.Instance.UpdateModels();
+
     protected override void OnSuccess()
     {
         // Don't have a way to dynamically reload paklump, just reset it

--- a/src/Lumper.UI/ViewModels/Pages/Jobs/StripperFileJobViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/Jobs/StripperFileJobViewModel.cs
@@ -26,6 +26,10 @@ public class StripperFileJobViewModel : JobViewModel
         this.WhenAnyValue(x => x.ConfigPath).BindTo(this, x => x.Job.ConfigPath);
     }
 
+    // Push viewmodel changes to model
+    protected override void Prepare() => BspService.Instance.EntityLumpViewModel?.UpdateModel();
+
+    // Push model changes to viewmodel
     protected override void OnSuccess() => BspService.Instance.EntityLumpViewModel?.UpdateViewModelFromModel();
 
     public async Task ShowFilePickerDialog()

--- a/src/Lumper.UI/ViewModels/Pages/Jobs/StripperTextJobViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/Jobs/StripperTextJobViewModel.cs
@@ -56,5 +56,9 @@ public class StripperTextJobViewModel : JobViewModel
         this.WhenAnyValue(x => x.Config).BindTo(this, x => x.Job.Config);
     }
 
+    // Push viewmodel changes to model
+    protected override void Prepare() => BspService.Instance.EntityLumpViewModel?.UpdateModel();
+
+    // Push model changes to viewmodel
     protected override void OnSuccess() => BspService.Instance.EntityLumpViewModel?.UpdateViewModelFromModel();
 }


### PR DESCRIPTION
Without this, if you change the entity lump via the entity editor then run a job, the job doesn't have the updated changes. The UpdateModel setup is gross and very anti-MVVM but whatever, alternative was also gross and don't want to refactor all that stuff again.