### PR TITLE
Fix auto-updater errors

### DIFF
--- a/src/Lumper.UI/Services/UpdaterService.cs
+++ b/src/Lumper.UI/Services/UpdaterService.cs
@@ -45,7 +45,7 @@ public sealed partial class UpdaterService : ReactiveObject
     /// Check whether the running executable is up-to-date with the latest release on Github
     /// <returns>Tuple of whether new release is available and the latest release</returns>
     /// </summary>
-    public async Task CheckForUpdates()
+    public async Task CheckForUpdates(bool log = false)
     {
         SemVer currentVersion = GetAssemblyVersion();
 
@@ -59,7 +59,11 @@ public sealed partial class UpdaterService : ReactiveObject
 
         if (GetAssemblyVersion() >= latestRelease.Version)
         {
-            _logger.Debug("Current build is up to date");
+            const string upToDate = "Current build is up to date";
+            if (log)
+                _logger.Info(upToDate);
+            else
+                _logger.Debug(upToDate);
             return;
         }
 

--- a/src/Lumper.UI/Services/UpdaterService.cs
+++ b/src/Lumper.UI/Services/UpdaterService.cs
@@ -178,18 +178,7 @@ public sealed partial class UpdaterService : ReactiveObject
         {
             // Using MS ZipArchive because SharpCompress is causing very weird System.Text.Encoding.CodePages errors
             // during ZipArchive.Open calls in release builds.
-            var zip = new ZipArchive(zipStream);
-            int numEntries = zip.Entries.Count;
-            if (numEntries == 0)
-                throw new InvalidDataException("No entries found in downloaded file");
-
-            foreach (ZipArchiveEntry entry in zip.Entries)
-            {
-                entry.ExtractToFile(Path.Combine(appDir, entry.Name), overwrite: true);
-                float prog = (float)(100 - downloadProgressProportion) / numEntries;
-                handler.UpdateProgress(prog, $"Extracting {entry.Name}");
-                _logger.Info($"Extracted {entry.Name}");
-            }
+            ZipFile.ExtractToDirectory(zipStream, AppContext.BaseDirectory, overwriteFiles: true);
         }
         catch (Exception ex)
         {

--- a/src/Lumper.UI/Views/MainWindow.axaml
+++ b/src/Lumper.UI/Views/MainWindow.axaml
@@ -115,7 +115,8 @@
               <MenuItem Header="_Export JSON Map Summary" Command="{Binding JsonDumpCommand}" />
             </MenuItem>
             <MenuItem Header="_About">
-              <MenuItem Header="_Check For Updates" Command="{Binding UpdaterService.CheckForUpdates}" />
+              <MenuItem Header="_Check For Updates" Command="{Binding UpdaterService.CheckForUpdates}"
+                        CommandParameter="true" />
               <Separator />
               <MenuItem Header="About" Command="{Binding AboutCommand}" />
             </MenuItem>


### PR DESCRIPTION
Simplifying the auto-updater to require a manual user restart, the cmd.exe process invocation approach wasn't working reliably and sometimes the updater errored when the .bak file still existed. 