### PR TITLE
Bump Dependencies

### DIFF
--- a/src/Lumper.CLI/Lumper.CLI.csproj
+++ b/src/Lumper.CLI/Lumper.CLI.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1"/>
-    <PackageReference Include="NLog" Version="5.3.4" />
+    <PackageReference Include="NLog" Version="5.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lumper.Lib/Lumper.Lib.csproj
+++ b/src/Lumper.Lib/Lumper.Lib.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="JsonSubTypes" Version="2.0.1"/>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-    <PackageReference Include="NLog" Version="5.3.4" />
+    <PackageReference Include="NLog" Version="5.4.0" />
     <PackageReference Include="SharpCompress" Version="0.39.0"/>
   </ItemGroup>
 

--- a/src/Lumper.UI/Lumper.UI.csproj
+++ b/src/Lumper.UI/Lumper.UI.csproj
@@ -14,21 +14,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.2.3" />
+    <PackageReference Include="Avalonia" Version="11.2.5" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.1.0" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Controls.TreeDataGrid" Version="11.1.0" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.3" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.5" />
+    <PackageReference Include="Avalonia.Controls.TreeDataGrid" Version="11.1.1" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.2.5" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.3" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.3" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.5" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.2.5" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.5" />
     <PackageReference Include="MessageBox.Avalonia" Version="3.2.0" />
     <PackageReference Include="ReactiveUI" Version="20.1.63" />
     <PackageReference Include="ReactiveUI.Fody" Version="19.5.41"/>
-    <PackageReference Include="Material.Icons.Avalonia" Version="2.2.0" />
-    <PackageReference Include="NLog" Version="5.3.4" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
+    <PackageReference Include="Material.Icons.Avalonia" Version="2.3.0" />
+    <PackageReference Include="NLog" Version="5.4.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
     <PackageReference Include="SharpCompress" Version="0.39.0" />
   </ItemGroup>
 


### PR DESCRIPTION
ImageSharp has a High CVE so upgrading to 3.1.7, doing everything else while I'm here.