### PR TITLE
Use fixed-width text encoding everywhere

### DIFF
--- a/src/Lumper.Lib/BSP/BspFile.cs
+++ b/src/Lumper.Lib/BSP/BspFile.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Lumper.Lib.Bsp.Enum;
@@ -24,6 +25,18 @@ public sealed partial class BspFile : IDisposable
     public const int HeaderSize = 1036;
 
     public const int MaxLumps = 128;
+
+    static BspFile()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        Encoding = Encoding.GetEncoding(1252);
+    }
+
+    // Source has little to no support for variable-length encodings like UTF-8, so we use
+    // Windows-1252 as it's the largest superset of all single-byte encodings.
+    // When working with anything encoding-specific, be sure to use this, not UTF-8.
+    // (for example SharpCompress defaults to UTF-8, and can corrupt paths in the pakfile archive).
+    public static readonly Encoding Encoding;
 
     public string? Name { get; private set; }
 

--- a/src/Lumper.Lib/BSP/BspFile.cs
+++ b/src/Lumper.Lib/BSP/BspFile.cs
@@ -144,13 +144,7 @@ public sealed partial class BspFile : IDisposable
             throw new ArgumentException("Not given a path to write to, and current BSP doesn't have a path");
 
         if (path is not null && Path.GetFileName(path) != FilePath && options.RenameCubemaps)
-        {
-            PakfileLump pakfile = GetLump<PakfileLump>();
-
-            Dictionary<string, string> modified = pakfile.RenameCubemapsPath(Path.GetFileName(path));
-            foreach (KeyValuePair<string, string> modifiedPath in modified)
-                pakfile.UpdatePathReferences(modifiedPath.Value, modifiedPath.Key, ".vmt");
-        }
+            RenameCubemaps(path);
 
         string outPath;
         string? backupPath = null;
@@ -369,6 +363,15 @@ public sealed partial class BspFile : IDisposable
         }
 
         return true;
+    }
+
+    private void RenameCubemaps(string path)
+    {
+        PakfileLump pakfile = GetLump<PakfileLump>();
+
+        Dictionary<string, string> modified = pakfile.RenameCubemapPaths(Path.GetFileName(path));
+        foreach ((string oldPath, string newPath) in modified)
+            pakfile.UpdatePathReferences(newPath, oldPath, ".vmt");
     }
 
     public bool SaveToStream(IoHandler handler, Stream stream, DesiredCompression compress)

--- a/src/Lumper.Lib/BSP/IO/BspFileReader.cs
+++ b/src/Lumper.Lib/BSP/IO/BspFileReader.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Lumper.Lib.Bsp.Enum;
 using Lumper.Lib.Bsp.Lumps;
 using Lumper.Lib.Bsp.Lumps.BspLumps;
@@ -57,7 +56,7 @@ public sealed class BspFileReader(BspFile file, Stream input, IoHandler? handler
 
         byte[] ident = ReadBytes(4);
 
-        if (Encoding.ASCII.GetString(ident) != "VBSP")
+        if (BspFile.Encoding.GetString(ident) != "VBSP")
             throw new InvalidDataException("File doesn't look like a VBSP");
 
         _bsp.Version = ReadInt32();
@@ -228,7 +227,7 @@ public sealed class BspFileReader(BspFile file, Stream input, IoHandler? handler
 
             texture.TexName =
                 end > 0
-                    ? Encoding.ASCII.GetString(texDataStringDataLump.Data, stringTableOffset, end - stringTableOffset)
+                    ? BspFile.Encoding.GetString(texDataStringDataLump.Data, stringTableOffset, end - stringTableOffset)
                     : "";
         }
     }

--- a/src/Lumper.Lib/BSP/IO/BspFileWriter.cs
+++ b/src/Lumper.Lib/BSP/IO/BspFileWriter.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Lumper.Lib.Bsp.Enum;
 using Lumper.Lib.Bsp.Lumps;
 using Lumps.BspLumps;
@@ -106,7 +105,7 @@ public sealed class BspFileWriter(BspFile file, Stream output, IoHandler? handle
         TexDataStringDataLump texDataStringDataLump = _bsp.GetLump<TexDataStringDataLump>();
 
         // Ensure stringdata lump can fit everything we're about to stuff in
-        texDataStringDataLump.Resize(texData.Sum(x => Encoding.ASCII.GetByteCount(x.TexName) + 1));
+        texDataStringDataLump.Resize(texData.Sum(x => BspFile.Encoding.GetByteCount(x.TexName) + 1));
 
         List<int> stringTable = [];
         int pos = 0;
@@ -117,7 +116,7 @@ public sealed class BspFileWriter(BspFile file, Stream output, IoHandler? handle
 
             tex.StringTablePointer = stringTable.Count - 1;
 
-            byte[] bytes = Encoding.ASCII.GetBytes(tex.TexName);
+            byte[] bytes = BspFile.Encoding.GetBytes(tex.TexName);
             Array.Copy(bytes, 0, texDataStringDataLump.Data, pos, bytes.Length);
             pos += bytes.Length;
             texDataStringDataLump.Data[pos] = 0;

--- a/src/Lumper.Lib/BSP/IO/LumpReader.cs
+++ b/src/Lumper.Lib/BSP/IO/LumpReader.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Lumper.Lib.Bsp.Enum;
 using Lumper.Lib.Bsp.Lumps;
 using Lumper.Lib.Bsp.Lumps.BspLumps;
@@ -16,7 +15,7 @@ using SharpCompress.Compressors.LZMA;
 /// Handles decompressing and fills lumps with data
 /// </summary>
 [JsonObject(MemberSerialization.OptIn)]
-public abstract class LumpReader(Stream input) : BinaryReader(input, encoding: Encoding.UTF8, leaveOpen: true)
+public abstract class LumpReader(Stream input) : BinaryReader(input, encoding: BspFile.Encoding, leaveOpen: true)
 {
     public List<Tuple<Lump, LumpHeaderInfo>> Lumps { get; set; } = [];
 
@@ -102,7 +101,7 @@ public abstract class LumpReader(Stream input) : BinaryReader(input, encoding: E
         MemoryStream decompressedStream = new();
 
         const string magic = "LZMA";
-        if (Encoding.ASCII.GetString(ReadBytes(magic.Length)) != magic)
+        if (BspFile.Encoding.GetString(ReadBytes(magic.Length)) != magic)
             throw new InvalidDataException("Failed to decompress: Lump doesn't look like it was LZMA compressed");
 
         uint actualSize = ReadUInt32();

--- a/src/Lumper.Lib/BSP/IO/LumpWriter.cs
+++ b/src/Lumper.Lib/BSP/IO/LumpWriter.cs
@@ -1,7 +1,6 @@
 namespace Lumper.Lib.Bsp.IO;
 
 using System.IO;
-using System.Text;
 using Lumper.Lib.Bsp.Enum;
 using Lumper.Lib.Bsp.Lumps;
 using Lumper.Lib.Bsp.Lumps.BspLumps;
@@ -15,7 +14,7 @@ using SharpCompress.Compressors.LZMA;
 /// This writer doesn't close its stream when disposed.
 /// </summary>
 [JsonObject(MemberSerialization.OptIn)]
-public abstract class LumpWriter(Stream output) : BinaryWriter(output, Encoding.UTF8, leaveOpen: true)
+public abstract class LumpWriter(Stream output) : BinaryWriter(output, BspFile.Encoding, leaveOpen: true)
 {
     protected abstract IoHandler? Handler { get; set; }
 

--- a/src/Lumper.Lib/BSP/Lumps/BspLumps/EntityLump.cs
+++ b/src/Lumper.Lib/BSP/Lumps/BspLumps/EntityLump.cs
@@ -142,18 +142,15 @@ public class EntityLump(BspFile parent) : ManagedLump<BspLumpType>(parent)
     {
         foreach (Entity ent in Data)
         {
-            // 28591 is extended ASCII - https://en.wikipedia.org/wiki/Extended_ASCII
-            // Encoding.ASCII is *7-bit* whereas 28591 is 8 bit - important as 8-bit ASCII is what the format uses
-            stream.Write(Encoding.GetEncoding(28591).GetBytes("{\n"));
-            foreach (Entity.EntityProperty prop in ent.Properties)
-            {
-                stream.Write(Encoding.GetEncoding(28591).GetBytes($"{prop}\n"));
-            }
+            stream.Write(BspFile.Encoding.GetBytes("{\n"));
 
-            stream.Write(Encoding.GetEncoding(28591).GetBytes("}\n"));
+            foreach (Entity.EntityProperty prop in ent.Properties)
+                stream.Write(BspFile.Encoding.GetBytes($"{prop}\n"));
+
+            stream.Write(BspFile.Encoding.GetBytes("}\n"));
         }
 
-        stream.Write(Encoding.GetEncoding(28591).GetBytes("\0"));
+        stream.Write(BspFile.Encoding.GetBytes("\0"));
     }
 
     public override bool Empty => Data.Count == 0;

--- a/src/Lumper.Lib/BSP/Lumps/BspLumps/PakFileLump.cs
+++ b/src/Lumper.Lib/BSP/Lumps/BspLumps/PakFileLump.cs
@@ -1,7 +1,6 @@
 namespace Lumper.Lib.Bsp.Lumps.BspLumps;
 
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -190,20 +189,13 @@ public partial class PakfileLump(BspFile parent) : ManagedLump<BspLumpType>(pare
 
             DataStream.Seek(DataStreamOffset, SeekOrigin.Begin);
 
-            byte[] buffer = ArrayPool<byte>.Shared.Rent(80 * 1024);
-            try
+            byte[] buffer = new byte[80 * 1024];
+            int read;
+            long remaining = DataStreamLength;
+            while ((read = DataStream.Read(buffer, 0, int.Min(buffer.Length, (int)remaining))) > 0)
             {
-                int read;
-                long remaining = DataStreamLength;
-                while ((read = DataStream.Read(buffer, 0, int.Min(buffer.Length, (int)remaining))) > 0)
-                {
-                    stream.Write(buffer, 0, read);
-                    remaining -= read;
-                }
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
+                stream.Write(buffer, 0, read);
+                remaining -= read;
             }
         }
         else if (compression == DesiredCompression.Uncompressed)

--- a/src/Lumper.Lib/BSP/Lumps/BspLumps/PakFileLump.cs
+++ b/src/Lumper.Lib/BSP/Lumps/BspLumps/PakFileLump.cs
@@ -49,12 +49,23 @@ public partial class PakfileLump(BspFile parent) : ManagedLump<BspLumpType>(pare
     /// </summary>
     public void UpdatePathReferences(string newPath, string oldPath, string? limitExtension = null)
     {
-        string[] opSplit = oldPath.Split('/');
-        string[] npSplit = newPath.Split('/');
+        UpdatePathReferencesInternal(newPath, oldPath, '/', limitExtension);
+        UpdatePathReferencesInternal(newPath, oldPath, '\\', limitExtension);
+    }
+
+    public void UpdatePathReferencesInternal(
+        string newPath,
+        string oldPath,
+        char separator,
+        string? limitExtension = null
+    )
+    {
+        string[] opSplit = oldPath.Split(separator);
+        string[] npSplit = newPath.Split(separator);
 
         // VMTs can reference VTFs ignoring the root directory and without the extension
-        oldPath = string.Join('/', opSplit[1..]);
-        newPath = string.Join('/', npSplit[1..]);
+        oldPath = string.Join(separator, opSplit[1..]);
+        newPath = string.Join(separator, npSplit[1..]);
         oldPath = Path.ChangeExtension(oldPath, "").TrimEnd('.');
         newPath = Path.ChangeExtension(newPath, "").TrimEnd('.');
 

--- a/src/Lumper.Lib/BSP/Lumps/GameLumps/StaticPropDictLump.cs
+++ b/src/Lumper.Lib/BSP/Lumps/GameLumps/StaticPropDictLump.cs
@@ -2,7 +2,6 @@ namespace Lumper.Lib.Bsp.Lumps.GameLumps;
 
 using System;
 using System.IO;
-using System.Text;
 using Lumper.Lib.Bsp.Enum;
 using NLog;
 
@@ -17,7 +16,7 @@ public class StaticPropDictLump(BspFile parent) : FixedLump<GameLumpType, string
     protected override void WriteItem(BinaryWriter writer, int index)
     {
         byte[] b = new byte[StructureSize];
-        byte[] value = Encoding.ASCII.GetBytes(Data[index]);
+        byte[] value = BspFile.Encoding.GetBytes(Data[index]);
         int count = value.Length;
         if (count > StructureSize)
         {

--- a/src/Lumper.Lib/Jobs/StripperTextJob.cs
+++ b/src/Lumper.Lib/Jobs/StripperTextJob.cs
@@ -1,7 +1,6 @@
 namespace Lumper.Lib.Jobs;
 
 using System.IO;
-using System.Text;
 using Lumper.Lib.Bsp;
 using Lumper.Lib.Bsp.Lumps.BspLumps;
 using Lumper.Lib.Stripper;
@@ -24,7 +23,7 @@ public class StripperTextJob : Job, IJob
             return false;
         }
 
-        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(Config));
+        using var stream = new MemoryStream(BspFile.Encoding.GetBytes(Config));
         var config = StripperConfig.Parse(stream);
 
         Progress.Max = config.Blocks.Count;

--- a/src/Lumper.Lib/Lumper.Lib.csproj
+++ b/src/Lumper.Lib/Lumper.Lib.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
     <PackageReference Include="NLog" Version="5.4.0" />
     <PackageReference Include="SharpCompress" Version="0.39.0"/>
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Lumper.UI/Services/BspService.cs
+++ b/src/Lumper.UI/Services/BspService.cs
@@ -1,7 +1,6 @@
 namespace Lumper.UI.Services;
 
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -227,7 +226,7 @@ public sealed class BspService : ReactiveObject, IDisposable
     private async Task<Stream?> HttpDownload(string url)
     {
         IoProgressWindow? progressWindow = null;
-        byte[] buffer = ArrayPool<byte>.Shared.Rent(80 * 1024);
+        byte[] buffer = new byte[80 * 1024];
         var cts = new CancellationTokenSource();
         var handler = new IoHandler(cts);
         var stream = new MemoryStream();

--- a/src/Lumper.UI/ViewModels/Pages/Jobs/StripperTextJobViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/Jobs/StripperTextJobViewModel.cs
@@ -3,7 +3,7 @@ namespace Lumper.UI.ViewModels.Pages.Jobs;
 using System;
 using System.IO;
 using System.Reactive.Linq;
-using System.Text;
+using Lumper.Lib.Bsp;
 using Lumper.Lib.Jobs;
 using Lumper.Lib.Stripper;
 using Lumper.UI.Services;
@@ -41,7 +41,7 @@ public class StripperTextJobViewModel : JobViewModel
                 // GetBytes is an extra copy but not that big of a deal, but don't want to refactor
                 // StripperConfig parsing to operate on a regular string. Perf hit is neglible.
                 bool success = StripperConfig.TryParse(
-                    new MemoryStream(Encoding.ASCII.GetBytes(x ?? "")),
+                    new MemoryStream(BspFile.Encoding.GetBytes(x ?? "")),
                     out _,
                     out string? errorMessage
                 );

--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
@@ -219,8 +219,8 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
         if (!GetSelection(out IReadOnlyList<Node> items, single: true))
             return;
 
-        IReadOnlyList<IStorageFile>? files = await PickFiles();
-        if (files is null || _pakfileLump is null)
+        IReadOnlyList<IStorageFile> files = await PickFiles();
+        if (_pakfileLump is null)
             return;
 
         List<string> branchPath = items[0].Path;
@@ -270,9 +270,7 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
         IMsBox<string> msBox = CreateMessageBox("Create Directory", "Directory Name", "Create");
         await ShowMessageBox(msBox);
 
-        string? name = msBox.InputValue;
-        if (name is null)
-            return;
+        string name = msBox.InputValue;
 
         List<string> pathList = [.. branchPath, name];
         Tree!.Root.AddDirectory(pathList);
@@ -288,7 +286,7 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
         IMsBox<string> msBox = CreateMessageBox("Create File", "File Name", "Create");
         await ShowMessageBox(msBox);
 
-        string name = msBox.InputValue ?? "new file";
+        string name = msBox.InputValue;
         if (name.EndsWith(".vtf", StringComparison.OrdinalIgnoreCase))
         {
             Logger.Error("Creating empty VTFs is not supported, please import one.");
@@ -320,9 +318,7 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
         if (result == "Cancel")
             return;
 
-        string? name = msBox.InputValue;
-        if (name is null)
-            return;
+        string name = msBox.InputValue;
 
         // This handles both leaf and branch nodes - PushTreeChangesToEntries does all the work.
         item.Name = name;

--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
@@ -202,14 +202,15 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
             }
 
             if (moveReferences)
+            {
                 await Observable.Start(
                     () => _pakfileLump!.UpdatePathReferences(newKey, node.Leaf.Key),
                     RxApp.TaskpoolScheduler
                 );
+            }
 
             // Update the actual key on the PakFileEntry - this is what causes the move to handle on save.
-            node.Leaf.Key = newKey;
-            node.Leaf.MarkAsModified();
+            node.Leaf.Rename(newKey);
         }
     }
 

--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
@@ -169,7 +169,7 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
     }
 
     // Note this doesn't handle deletions, kept in DeleteSelected for now
-    private async ValueTask PushTreeChangesToEntries()
+    private async Task PushTreeChangesToEntries()
     {
         // TODO: size updates?
         if (Tree is null)

--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
@@ -205,7 +205,7 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
             {
                 await Observable.Start(
                     () => _pakfileLump!.UpdatePathReferences(newKey, node.Leaf.Key),
-                    RxApp.TaskpoolScheduler
+                    RxApp.MainThreadScheduler // Must be main thread, calls a bunch of viewmodel setters.
                 );
             }
 

--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
@@ -370,7 +370,10 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
         string rootPath = folder.Path.LocalPath;
         var exportDir = new DirectoryInfo(rootPath);
         if (!exportDir.Exists)
-            throw new DirectoryNotFoundException(rootPath);
+        {
+            Logger.Error($"{rootPath} does not exist, cannot export.");
+            return;
+        }
 
         try
         {
@@ -409,10 +412,13 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
         if (folder is null || _pakfileLump is null)
             return;
 
-        string rootPath = folder.Path.AbsolutePath;
+        string rootPath = folder.Path.LocalPath;
         var exportDir = new DirectoryInfo(rootPath);
         if (!exportDir.Exists)
-            throw new DirectoryNotFoundException(rootPath);
+        {
+            Logger.Error($"{rootPath} does not exist, cannot export.");
+            return;
+        }
 
         string commonParentPath = Node.FindCommonAncestor(nodes).PathString + '/';
         try

--- a/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryTextViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryTextViewModel.cs
@@ -3,9 +3,9 @@ namespace Lumper.UI.ViewModels.Shared.Pakfile;
 using System;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Lumper.Lib.Bsp;
 using Lumper.Lib.Bsp.Struct;
 using Lumper.UI.Views.Shared.Pakfile;
 using NLog;
@@ -36,7 +36,7 @@ public class PakfileEntryTextViewModel : PakfileEntryViewModel
     {
         try
         {
-            Content = Encoding.ASCII.GetString(GetData());
+            Content = BspFile.Encoding.GetString(GetData());
         }
         catch
         {
@@ -69,6 +69,6 @@ public class PakfileEntryTextViewModel : PakfileEntryViewModel
         if (!IsModified)
             return;
 
-        UpdateData(Encoding.ASCII.GetBytes(Content ?? ""));
+        UpdateData(BspFile.Encoding.GetBytes(Content ?? ""));
     }
 }

--- a/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryViewModel.cs
@@ -17,10 +17,9 @@ public abstract class PakfileEntryViewModel : HierarchicalBspNode
     public string Key
     {
         get => _key;
-        set
+        private set
         {
             _key = value;
-            BaseEntry.Key = value;
             var fi = new FileInfo(value);
             // We often load hundreds of these at once, bad for perf to WhenAnyValue => ToProperty observables for
             // each - just use setters and [Reactive] RaiseAndSetIfChanged.
@@ -51,6 +50,13 @@ public abstract class PakfileEntryViewModel : HierarchicalBspNode
     }
 
     public abstract void Load(CancellationTokenSource? cts = null);
+
+    public void Rename(string newName)
+    {
+        Key = newName;
+        BaseEntry.Rename(newName);
+        MarkAsModified();
+    }
 
     public override void MarkAsModified()
     {

--- a/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileLumpViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileLumpViewModel.cs
@@ -31,7 +31,7 @@ public sealed class PakfileLumpViewModel : BspNode, ILumpViewModel
         InitEntries();
     }
 
-    public void UpdateEntries(bool checkIfModified) =>
+    public void UpdateViewModelFromModel(bool checkIfModified) =>
         Entries.Edit(updater =>
         {
             foreach (PakfileEntry entry in _pakfile.Entries.OrderBy(x => new FileInfo(x.Key).Name))
@@ -39,9 +39,15 @@ public sealed class PakfileLumpViewModel : BspNode, ILumpViewModel
                 if (entry.IsModified || !checkIfModified)
                     updater.AddOrUpdate(CreateEntryViewModel(entry));
             }
+
+            foreach (PakfileEntryViewModel entry in Entries.Items.ToList())
+            {
+                if (_pakfile.Entries.All(x => x.Key != entry.Key))
+                    updater.Remove(entry);
+            }
         });
 
-    private void InitEntries() => UpdateEntries(false);
+    private void InitEntries() => UpdateViewModelFromModel(false);
 
     private PakfileEntryViewModel CreateEntryViewModel(PakfileEntry entry) =>
         entry.Key.EndsWith(".vtf", StringComparison.OrdinalIgnoreCase)

--- a/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileLumpViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileLumpViewModel.cs
@@ -291,6 +291,22 @@ public sealed class PakfileLumpViewModel : BspNode, ILumpViewModel
             if (changes > 0)
                 Logger.Info($"Replaced {changes} instances of {updatedOp} with {updatedNp} in file {entry.Key}");
         }
+
+        // TexData - doesn't have viewmodels (yay!)
+        if (oldPath.EndsWith(".vmt", cmp) && opPrefix.Equals("materials", cmp))
+        {
+            string op = opNoPrefix[..^4]; // Trim .vtf
+            string np = string.Join('/', newPath.Split('/')[1..])[..^4]; // Trim materials/ and .vtf
+            TexDataLump? texdataLump = BspService.Instance.BspFile?.GetLump<TexDataLump>();
+            if (texdataLump is null)
+                throw new InvalidDataException("TexDataLump not found (??)");
+
+            foreach (TexData texData in texdataLump.Data)
+            {
+                if (texData.TexName.Equals(op, cmp))
+                    texData.TexName = np;
+            }
+        }
     }
 
     public void Dispose()

--- a/src/Lumper.UI/Views/MainWindow.axaml.cs
+++ b/src/Lumper.UI/Views/MainWindow.axaml.cs
@@ -24,7 +24,6 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 
         this.WhenActivated(disposables =>
         {
-            AddHandler(DragDrop.DragOverEvent, Window_OnDragOver);
             AddHandler(DragDrop.DropEvent, Window_OnDrop);
 
             // Stupid shit to get this to behave like a radiobutton. I miss Angular
@@ -114,12 +113,6 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
     {
         List<IStorageFile> files = FilterDraggedBspFiles(e);
         await ViewModel!.OpenDragDropped(files);
-    }
-
-    private void Window_OnDragOver(object? _, DragEventArgs e)
-    {
-        bool hasBsps = FilterDraggedBspFiles(e).Count > 0;
-        e.DragEffects = hasBsps ? DragDropEffects.Link : DragDropEffects.None;
     }
 
     private List<IStorageFile> FilterDraggedBspFiles(DragEventArgs e) =>

--- a/src/Lumper.UI/Views/Pages/Jobs/StripperTextJobView.axaml.cs
+++ b/src/Lumper.UI/Views/Pages/Jobs/StripperTextJobView.axaml.cs
@@ -3,10 +3,10 @@ namespace Lumper.UI.Views.Pages.Jobs;
 using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
-using System.Text;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.ReactiveUI;
+using Lumper.Lib.Bsp;
 using Lumper.UI.ViewModels.Pages.Jobs;
 using ReactiveUI;
 
@@ -32,7 +32,7 @@ public partial class StripperTextJobView : ReactiveUserControl<StripperTextJobVi
                     .ObserveOn(RxApp.MainThreadScheduler)
             );
 
-            TextEditor.Encoding = Encoding.ASCII;
+            TextEditor.Encoding = BspFile.Encoding;
             TextEditor.ContextMenu = new ContextMenu
             {
                 ItemsSource = new List<MenuItem>

--- a/src/Lumper.UI/Views/Pages/RawEntities/RawEntitiesView.axaml.cs
+++ b/src/Lumper.UI/Views/Pages/RawEntities/RawEntitiesView.axaml.cs
@@ -4,11 +4,11 @@ using System;
 using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
-using System.Text;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.ReactiveUI;
 using AvaloniaEdit;
+using Lumper.Lib.Bsp;
 using Lumper.UI.Services;
 using Lumper.UI.ViewModels.Pages.RawEntities;
 using ReactiveUI;
@@ -20,7 +20,7 @@ public partial class RawEntitiesView : ReactiveUserControl<RawEntitiesViewModel>
         InitializeComponent();
 
         TextEditor editor = this.FindControl<TextEditor>("TextEditor")!;
-        editor.Encoding = Encoding.ASCII;
+        editor.Encoding = BspFile.Encoding;
         editor.ShowLineNumbers = true;
         editor.ContextMenu = new ContextMenu
         {

--- a/src/Lumper.UI/Views/Shared/Pakfile/PakfileEntryTextView.axaml.cs
+++ b/src/Lumper.UI/Views/Shared/Pakfile/PakfileEntryTextView.axaml.cs
@@ -3,11 +3,11 @@ namespace Lumper.UI.Views.Shared.Pakfile;
 using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
-using System.Text;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.ReactiveUI;
+using Lumper.Lib.Bsp;
 using Lumper.UI.ViewModels.Shared.Pakfile;
 using ReactiveUI;
 
@@ -37,7 +37,7 @@ public partial class PakfileEntryTextView : ReactiveUserControl<PakfileEntryText
             };
             TextEditor.TextChanged += handler;
 
-            TextEditor.Encoding = Encoding.ASCII;
+            TextEditor.Encoding = BspFile.Encoding;
             TextEditor.ContextMenu = new ContextMenu
             {
                 ItemsSource = new List<MenuItem>


### PR DESCRIPTION
Previously the pakfile was getting processed using UTF-8, which breaks for any non-ASCII characters. After discussing internally a bit, we've decided to go with Windows-1252 as it's the largest set of fixed-width encodings.

This fixes the broken jackfruit textured ramp on surf_fruits, whose VMT was getting written to a mangled path in the pakfile due to it having a U with an umlaut in.

Note: rebased on top of https://github.com/momentum-mod/lumper/pull/130 due to some overlap