### PR TITLE
Fix filenames getting trucated on export

### DIFF
--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
@@ -420,7 +420,10 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
             return;
         }
 
-        string commonParentPath = Node.FindCommonAncestor(nodes).PathString + '/';
+        string commonParentPath = Node.FindCommonAncestor(nodes).PathString;
+        if (!string.IsNullOrEmpty(commonParentPath))
+            commonParentPath += '/';
+
         try
         {
             foreach (


### PR DESCRIPTION
If the common ancestor is the root path, we don't need to remove anything from the entry path. In that case commonParentPath.Length needs to be 0 but adding a slash makes it 1, which removes the first letter of the entry path. Therefore only add a slash if not in root directory.
Closes #107