### PR TITLE
Gamelump corruption fixes

### DIFF
--- a/src/Lumper.Lib/BSP/IO/GameLumpReader.cs
+++ b/src/Lumper.Lib/BSP/IO/GameLumpReader.cs
@@ -60,12 +60,11 @@ public sealed class GameLumpReader(GameLump gamelump, Stream input, long length,
 
             var header = new LumpHeaderInfo { Offset = ReadInt32(), UncompressedLength = ReadInt32() };
 
+            // Get the actual size on disk for the previous lump, based on the current lump's offset.
+            // If the offset is 0, it's a null entry, use the remaining length of the gamelump instead.
             if (prevHeader != null)
             {
-                long actualLength = header.Offset - prevHeader.Offset;
-                if (actualLength < 0)
-                    actualLength = length - (prevHeader.Offset + prevHeader.Length - startPos);
-
+                long actualLength = (header.Offset > 0 ? header.Offset : startPos + length) - prevHeader.Offset;
                 prevHeader.CompressedLength = prevCompressed ? actualLength : -1;
             }
 

--- a/src/Lumper.Lib/BSP/Lumps/GameLumps/Sprp.cs
+++ b/src/Lumper.Lib/BSP/Lumps/GameLumps/Sprp.cs
@@ -80,8 +80,5 @@ public class Sprp(BspFile parent) : ManagedLump<GameLumpType>(parent)
         }
     }
 
-    public override bool Empty =>
-        (StaticProps is null || StaticProps.Empty)
-        && (StaticPropsDict is null || StaticPropsDict.Empty)
-        && (StaticPropsLeaf is null || StaticPropsLeaf.Empty);
+    public override bool Empty => StaticProps is null && StaticPropsDict is null && StaticPropsLeaf is null;
 }


### PR DESCRIPTION
Fixes #151
Plus another small issue I noticed, when the sprp has no entries it should still contain the 3 entry counts (which are all 0), this however did not get written on save since the lump is considered empty. Didn't seem to break anything but the data of the lump probably shouldn't arbitrarily be deleted like that.