### PR TITLE
Statement-bodied methods and constructors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,6 @@
 # Copied from https://github.com/RehanSaeed/EditorConfig on 19/03/2024
 # Modified by Tom quite a bit.
 # Don't ignore warnings, they'll fail QA CI for your PR. Bring it up in Discord if there are rules you can't tolerate.
-
-# Version: 4.1.1 (Using https://semver.org/)
-# Updated: 2022-05-23
-# See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
-# See https://github.com/RehanSaeed/EditorConfig for updates to this file.
-# See http://EditorConfig.org for more information about .editorconfig files.
 # @formatter:off
 
 [src/Dependencies/**/*.cs]
@@ -142,9 +136,9 @@ csharp_style_var_for_built_in_types = false:warning
 csharp_style_var_when_type_is_apparent = true:warning
 csharp_style_var_elsewhere = false:warning
 
-# Expression-bodied members
-csharp_style_expression_bodied_methods = true:warning
-csharp_style_expression_bodied_constructors = true:warning
+# Expression-bodied members can be hard to read when you have a lot in one class, especially constructors.
+csharp_style_expression_bodied_methods = false:warning
+csharp_style_expression_bodied_constructors = false:warning
 csharp_style_expression_bodied_operators = true:warning
 csharp_style_expression_bodied_properties = true:warning
 csharp_style_expression_bodied_indexers = true:warning
@@ -411,39 +405,3 @@ dotnet_naming_symbols.parameters_group.applicable_kinds = parameter
 dotnet_naming_rule.parameters_rule.symbols              = parameters_group
 dotnet_naming_rule.parameters_rule.style                = camel_case_style
 dotnet_naming_rule.parameters_rule.severity             = warning
-
-# Why does an .editorconfig need a copyright and license? Fuck knows!
-##########################################
-# License
-##########################################
-# The following applies as to the .editorconfig file ONLY, and is
-# included below for reference, per the requirements of the license
-# corresponding to this .editorconfig file.
-# See: https://github.com/RehanSaeed/EditorConfig
-#
-# MIT License
-#
-# Copyright (c) 2017-2019 Muhammad Rehan Saeed
-# Copyright (c) 2019 Henry Gabryjelski
-#
-# Permission is hereby granted, free of charge, to any
-# person obtaining a copy of this software and associated
-# documentation files (the "Software"), to deal in the
-# Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute,
-# sublicense, and/or sell copies of the Software, and to permit
-# persons to whom the Software is furnished to do so, subject
-# to the following conditions:
-#
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-# OTHER DEALINGS IN THE SOFTWARE.
-##########################################

--- a/src/Lumper.CLI/Program.cs
+++ b/src/Lumper.CLI/Program.cs
@@ -137,7 +137,8 @@ internal sealed class Program
         return true;
     }
 
-    private static void JsonDump(BspFile bspFile, CommandLineOptions options) =>
+    private static void JsonDump(BspFile bspFile, CommandLineOptions options)
+    {
         bspFile.JsonDump(
             options.JsonPath ?? null,
             null,
@@ -145,6 +146,7 @@ internal sealed class Program
             sortProperties: options.JsonOptions.HasFlag(JsonOptions.SortProperties),
             ignoreOffset: options.JsonOptions.HasFlag(JsonOptions.IgnoreOffset)
         );
+    }
 
     private static void RunWorkflow(BspFile bspFile, string workflowPath)
     {

--- a/src/Lumper.Lib/AssetManifest/AssetManifest.cs
+++ b/src/Lumper.Lib/AssetManifest/AssetManifest.cs
@@ -44,7 +44,10 @@ public static class AssetManifest
     /// <summary>
     /// Preload the asset manifest. UI wants this, CLI doesn't. Don't call from the UI thread!
     /// </summary>
-    public static void Preload() => _ = Manifest;
+    public static void Preload()
+    {
+        _ = Manifest;
+    }
 
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 

--- a/src/Lumper.Lib/BSP/BspFile.cs
+++ b/src/Lumper.Lib/BSP/BspFile.cs
@@ -65,10 +65,15 @@ public sealed partial class BspFile : IDisposable
     // creating a BspFile instance without loading an actual BSP.
     private BspFile() { }
 
-    public static BspFile? FromPath(string path, IoHandler? handler) =>
-        new BspFile { Name = Path.GetFileNameWithoutExtension(path) }.Load(path, handler);
+    public static BspFile? FromPath(string path, IoHandler? handler)
+    {
+        return new BspFile { Name = Path.GetFileNameWithoutExtension(path) }.Load(path, handler);
+    }
 
-    public static BspFile? FromStream(Stream stream, IoHandler? handler) => new BspFile().Load(stream, handler);
+    public static BspFile? FromStream(Stream stream, IoHandler? handler)
+    {
+        return new BspFile().Load(stream, handler);
+    }
 
     public BspFile? Load(string path, IoHandler? handler)
     {
@@ -408,13 +413,22 @@ public sealed partial class BspFile : IDisposable
     }
 
     public T GetLump<T>()
-        where T : Lump<BspLumpType> => Lumps.Values.OfType<T>().First();
+        where T : Lump<BspLumpType>
+    {
+        return Lumps.Values.OfType<T>().First();
+    }
 
-    public Lump<BspLumpType> GetLump(BspLumpType lumpType) => Lumps[lumpType];
+    public Lump<BspLumpType> GetLump(BspLumpType lumpType)
+    {
+        return Lumps[lumpType];
+    }
 
     // I tried to refactor a bunch of code to use URIs everywhere but was a big hassle and Uri ctor apparently
     // doesn't handle escaped stuff well... just sticking with strings
-    private static string GetUnescapedFilePathString(string path) => Uri.UnescapeDataString(Path.GetFullPath(path));
+    private static string GetUnescapedFilePathString(string path)
+    {
+        return Uri.UnescapeDataString(Path.GetFullPath(path));
+    }
 
     public void JsonDump(string? path, IoHandler? handler, bool sortLumps, bool sortProperties, bool ignoreOffset)
     {
@@ -457,5 +471,8 @@ public sealed partial class BspFile : IDisposable
     [GeneratedRegex("\\.bsp$")]
     public static partial Regex BspExtensionRegex();
 
-    public void Dispose() => FileStream?.Dispose();
+    public void Dispose()
+    {
+        FileStream?.Dispose();
+    }
 }

--- a/src/Lumper.Lib/BSP/Lumps/BspLumps/EntityLump.cs
+++ b/src/Lumper.Lib/BSP/Lumps/BspLumps/EntityLump.cs
@@ -15,8 +15,10 @@ public class EntityLump(BspFile parent) : ManagedLump<BspLumpType>(parent)
 
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-    public override void Read(BinaryReader reader, long length, IoHandler? handler = null) =>
+    public override void Read(BinaryReader reader, long length, IoHandler? handler = null)
+    {
         Read(reader, length, false);
+    }
 
     /// <summary>
     /// Parse an entity lump using a BinaryReader on a stream.

--- a/src/Lumper.Lib/BSP/Lumps/BspLumps/GameLump.cs
+++ b/src/Lumper.Lib/BSP/Lumps/BspLumps/GameLump.cs
@@ -19,9 +19,15 @@ public class GameLump(BspFile parent) : ManagedLump<BspLumpType>(parent)
     }
 
     public T? GetLump<T>()
-        where T : Lump<GameLumpType> => (T?)Lumps.Values.First(x => x?.GetType() == typeof(T));
+        where T : Lump<GameLumpType>
+    {
+        return (T?)Lumps.Values.First(x => x?.GetType() == typeof(T));
+    }
 
-    public Lump<GameLumpType>? GetLump(GameLumpType lumpType) => Lumps[lumpType];
+    public Lump<GameLumpType>? GetLump(GameLumpType lumpType)
+    {
+        return Lumps[lumpType];
+    }
 
     public override void Read(BinaryReader reader, long length, IoHandler? handler = null)
     {

--- a/src/Lumper.Lib/BSP/Lumps/BspLumps/PakFileLump.Refactoring.cs
+++ b/src/Lumper.Lib/BSP/Lumps/BspLumps/PakFileLump.Refactoring.cs
@@ -373,8 +373,9 @@ public partial class PakfileLump
     }
 
     // C isspace https://en.cppreference.com/w/c/string/byte/isspace
-    private static bool IsWhitespace(char c) =>
-        c switch
+    private static bool IsWhitespace(char c)
+    {
+        return c switch
         {
             ' ' => true,
             '\t' => true,
@@ -384,6 +385,7 @@ public partial class PakfileLump
             '\f' => true,
             _ => false,
         };
+    }
 
     private bool UpdateTexDataPathReferences(string oldPath, string newPath, string opPrefix, string opNoPrefix)
     {

--- a/src/Lumper.Lib/BSP/Lumps/BspLumps/TexDataStringDataLump.cs
+++ b/src/Lumper.Lib/BSP/Lumps/BspLumps/TexDataStringDataLump.cs
@@ -20,15 +20,22 @@ public class TexDataStringDataLump(BspFile parent) : ManagedLump<BspLumpType>(pa
         private set => _data = value;
     }
 
-    public override void Read(BinaryReader reader, long length, IoHandler? handler = null) =>
+    public override void Read(BinaryReader reader, long length, IoHandler? handler = null)
+    {
         Data = reader.ReadBytes((int)length);
+    }
 
-    public override void Write(Stream stream, IoHandler? handler = null, DesiredCompression? compression = null) =>
+    public override void Write(Stream stream, IoHandler? handler = null, DesiredCompression? compression = null)
+    {
         stream.Write(Data, 0, Data.Length);
+    }
 
     public override bool Empty => Data.Length <= 0;
 
-    public void Resize(int newSize) => Array.Resize(ref _data, newSize);
+    public void Resize(int newSize)
+    {
+        Array.Resize(ref _data, newSize);
+    }
 }
 
 public class ByteArrayJsonConverter : JsonConverter<byte[]>
@@ -47,7 +54,10 @@ public class ByteArrayJsonConverter : JsonConverter<byte[]>
         byte[]? existingValue,
         bool hasExistingValue,
         JsonSerializer serializer
-    ) => throw new NotImplementedException("Unnecessary because CanRead is false. The type will skip the converter.");
+    )
+    {
+        throw new NotImplementedException("Unnecessary because CanRead is false. The type will skip the converter.");
+    }
 
     public override bool CanRead => false;
 }

--- a/src/Lumper.Lib/BSP/Lumps/BspLumps/TexDataStringTableLump.cs
+++ b/src/Lumper.Lib/BSP/Lumps/BspLumps/TexDataStringTableLump.cs
@@ -8,7 +8,13 @@ public class TexDataStringTableLump(BspFile parent) : FixedLump<BspLumpType, int
 {
     public override int StructureSize => 4;
 
-    protected override void ReadItem(BinaryReader reader) => Data.Add(reader.ReadInt32());
+    protected override void ReadItem(BinaryReader reader)
+    {
+        Data.Add(reader.ReadInt32());
+    }
 
-    protected override void WriteItem(BinaryWriter writer, int index) => writer.Write(Data[index]);
+    protected override void WriteItem(BinaryWriter writer, int index)
+    {
+        writer.Write(Data[index]);
+    }
 }

--- a/src/Lumper.Lib/BSP/Lumps/GameLumps/StaticPropDictLump.cs
+++ b/src/Lumper.Lib/BSP/Lumps/GameLumps/StaticPropDictLump.cs
@@ -11,8 +11,10 @@ public class StaticPropDictLump(BspFile parent) : FixedLump<GameLumpType, string
 
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-    protected override void ReadItem(BinaryReader reader) =>
+    protected override void ReadItem(BinaryReader reader)
+    {
         Data.Add(new string(reader.ReadChars(StructureSize)).TrimEnd('\0'));
+    }
 
     protected override void WriteItem(BinaryWriter writer, int index)
     {

--- a/src/Lumper.Lib/BSP/Lumps/GameLumps/StaticPropLump.cs
+++ b/src/Lumper.Lib/BSP/Lumps/GameLumps/StaticPropLump.cs
@@ -30,7 +30,8 @@ public class StaticPropLump(BspFile parent) : FixedLump<GameLumpType, StaticProp
             _ => 1,
         };
 
-    public void SetVersion(int version) =>
+    public void SetVersion(int version)
+    {
         ActualVersion = version switch
         {
             4 => StaticPropVersion.V4,
@@ -45,9 +46,11 @@ public class StaticPropLump(BspFile parent) : FixedLump<GameLumpType, StaticProp
             13 => StaticPropVersion.V13,
             _ => StaticPropVersion.Unknown,
         };
+    }
 
-    public int GetVersion() =>
-        ActualVersion switch
+    public int GetVersion()
+    {
+        return ActualVersion switch
         {
             StaticPropVersion.V4 => 4,
             StaticPropVersion.V5 => 5,
@@ -62,6 +65,7 @@ public class StaticPropLump(BspFile parent) : FixedLump<GameLumpType, StaticProp
             StaticPropVersion.V13 => 13,
             _ => 0,
         };
+    }
 
     protected override void ReadItem(BinaryReader reader)
     {

--- a/src/Lumper.Lib/BSP/Struct/Entity.cs
+++ b/src/Lumper.Lib/BSP/Struct/Entity.cs
@@ -18,10 +18,12 @@ public partial class Entity : ICloneable
 
     public List<EntityProperty> Properties { get; set; }
 
-    public Entity(IEnumerable<KeyValuePair<string, string>>? kv) =>
+    public Entity(IEnumerable<KeyValuePair<string, string>>? kv)
+    {
         Properties = kv is not null
             ? kv.Select(x => EntityProperty.Create(x, EntityLumpVersion)).OfType<EntityProperty>().ToList()
             : [];
+    }
 
     /// <summary>
     /// Provides a user-friendly name for the entity. classnames aren't unique and hammerids
@@ -84,7 +86,10 @@ public partial class Entity : ICloneable
         return Vector3.DistanceSquared(origin.Value, position) <= Math.Pow(radius, 2);
     }
 
-    public object Clone() => new Entity { Properties = Properties.Select(x => (EntityProperty)x.Clone()).ToList() };
+    public object Clone()
+    {
+        return new Entity { Properties = Properties.Select(x => (EntityProperty)x.Clone()).ToList() };
+    }
 
     public abstract class EntityProperty(string key) : ICloneable
     {
@@ -92,12 +97,17 @@ public partial class Entity : ICloneable
 
         public abstract string ValueString { get; }
 
-        public override string ToString() => $"\"{Key}\" \"{ValueString}\"";
+        public override string ToString()
+        {
+            return $"\"{Key}\" \"{ValueString}\"";
+        }
 
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public static EntityProperty? Create(KeyValuePair<string, string> kv, int elVersion = 0) =>
-            Create(kv.Key, kv.Value, elVersion);
+        public static EntityProperty? Create(KeyValuePair<string, string> kv, int elVersion = 0)
+        {
+            return Create(kv.Key, kv.Value, elVersion);
+        }
 
         public static EntityProperty? Create(string key, string value, int elVersion = 0)
         {
@@ -131,6 +141,9 @@ public partial class Entity : ICloneable
 
         public override string ValueString => Value.ToString() ?? "";
 
-        public override object Clone() => new EntityProperty<T>(Key, (T)Value.Clone());
+        public override object Clone()
+        {
+            return new EntityProperty<T>(Key, (T)Value.Clone());
+        }
     }
 }

--- a/src/Lumper.Lib/BSP/Struct/EntityIO.cs
+++ b/src/Lumper.Lib/BSP/Struct/EntityIO.cs
@@ -16,7 +16,10 @@ public partial class EntityIo : ICloneable
 
     public char Separator { get; }
 
-    public EntityIo(char separator) => Separator = separator;
+    public EntityIo(char separator)
+    {
+        Separator = separator;
+    }
 
     private EntityIo(string value, char separator)
     {
@@ -90,14 +93,19 @@ public partial class EntityIo : ICloneable
     }
 
     // csharpier-ignore
-    public override string ToString() =>
-          TargetEntityName + Separator
+    public override string ToString()
+    {
+        return TargetEntityName + Separator
         + Input + Separator
         + Parameter + Separator
         + Delay.ToString(CultureInfo.InvariantCulture) + Separator
         + TimesToFire.ToString(CultureInfo.InvariantCulture);
+    }
 
-    public object Clone() => MemberwiseClone();
+    public object Clone()
+    {
+        return MemberwiseClone();
+    }
 
     // Match string,string,string,number,number where numbers can be decimals, negative, -.xxx
     [GeneratedRegex(@"^[^,]*,[^,]*,[^,]*(,(-?\d*\.?\d+)?){2}$")]

--- a/src/Lumper.Lib/Jobs/JobProgress.cs
+++ b/src/Lumper.Lib/Jobs/JobProgress.cs
@@ -30,7 +30,10 @@ public class JobProgress
 
     public event PercentChangedHandler? OnPercentChanged;
 
-    public JobProgress(long max = -1) => Max = max;
+    public JobProgress(long max = -1)
+    {
+        Max = max;
+    }
 
     private void UpdatePercent()
     {

--- a/src/Lumper.Lib/Stripper/StripperConfig.cs
+++ b/src/Lumper.Lib/Stripper/StripperConfig.cs
@@ -85,8 +85,13 @@ public partial class StripperConfig
     [GeneratedRegex("\"([^\"]+)\"\\s+\"([^\"]+)\"", RegexOptions.IgnoreCase)]
     private static partial Regex PairRegex();
 
-    private static bool IsComment(string line) =>
-        line.StartsWith(';') || line.StartsWith("//", StringComparison.Ordinal) || line.StartsWith('#') || line == "";
+    private static bool IsComment(string line)
+    {
+        return line.StartsWith(';')
+            || line.StartsWith("//", StringComparison.Ordinal)
+            || line.StartsWith('#')
+            || line == "";
+    }
 
     private static bool MatchKeyValue(KvPair filter, Entity.EntityProperty property)
     {
@@ -160,8 +165,10 @@ public partial class StripperConfig
     {
         public List<KvPair> Properties { get; set; } = [];
 
-        public override void Parse(StreamReader reader, bool blockOpen, ref int lineNr) =>
+        public override void Parse(StreamReader reader, bool blockOpen, ref int lineNr)
+        {
             ParseBlock(reader, blockOpen, ref lineNr, (line, lNr) => Properties.Add(ParseProperty(line, lNr)));
+        }
 
         public override void Apply(EntityLump lump)
         {
@@ -175,8 +182,10 @@ public partial class StripperConfig
     {
         public List<KvPair> Properties { get; set; } = [];
 
-        public override void Parse(StreamReader reader, bool blockOpen, ref int lineNr) =>
+        public override void Parse(StreamReader reader, bool blockOpen, ref int lineNr)
+        {
             ParseBlock(reader, blockOpen, ref lineNr, (line, lNr) => Properties.Add(ParseProperty(line, lNr)));
+        }
 
         public override void Apply(EntityLump lump)
         {

--- a/src/Lumper.Test/PakfileRefactoringTests.cs
+++ b/src/Lumper.Test/PakfileRefactoringTests.cs
@@ -331,7 +331,8 @@ public class PakFileLumpRefactoringTests
     }
 
     [Test]
-    public void Pakfile_ExactMatch_UpdatesPath() =>
+    public void Pakfile_ExactMatch_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/foo.vtf",
@@ -349,9 +350,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_NoMatch_ReturnsEmpty() =>
+    public void Pakfile_NoMatch_ReturnsEmpty()
+    {
         TestPakfile(
             false,
             "materials/test/foo.vtf",
@@ -369,9 +372,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_HandlesMultiplePathsInSameFile_UpdatesAllMatches() =>
+    public void Pakfile_HandlesMultiplePathsInSameFile_UpdatesAllMatches()
+    {
         TestPakfile(
             true,
             "materials/test/foo.vtf",
@@ -395,9 +400,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_CaseInsensitiveMatching_UpdatesPath() =>
+    public void Pakfile_CaseInsensitiveMatching_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/foo.vtf",
@@ -415,9 +422,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_WithExtension_UpdatesPath() =>
+    public void Pakfile_WithExtension_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/foo.vtf",
@@ -435,9 +444,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_WithDirectory_ReturnsEmpty() =>
+    public void Pakfile_WithDirectory_ReturnsEmpty()
+    {
         TestPakfile(
             false,
             "materials/test/foo.vtf",
@@ -455,9 +466,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_WithDirectoryAndExtension_ReturnsEmpty() =>
+    public void Pakfile_WithDirectoryAndExtension_ReturnsEmpty()
+    {
         TestPakfile(
             false,
             "materials/test/foo.vtf",
@@ -475,9 +488,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_GenericTextFile_UpdatesPath() =>
+    public void Pakfile_GenericTextFile_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/foo.vtf",
@@ -492,9 +507,11 @@ public class PakFileLumpRefactoringTests
             """,
             "readme.txt"
         );
+    }
 
     [Test]
-    public void Pakfile_GenericTextFileWithoutExtension_ReturnsEmpty() =>
+    public void Pakfile_GenericTextFileWithoutExtension_ReturnsEmpty()
+    {
         TestPakfile(
             false,
             "materials/test/foo.vtf",
@@ -509,9 +526,11 @@ public class PakFileLumpRefactoringTests
             """,
             "readme.txt"
         );
+    }
 
     [Test]
-    public void Pakfile_VmtWithMissingQuotes_UpdatesPath() =>
+    public void Pakfile_VmtWithMissingQuotes_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/foo.vtf",
@@ -529,9 +548,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_VmtWithMissingQuotesWithExtension_UpdatesPath() =>
+    public void Pakfile_VmtWithMissingQuotesWithExtension_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/foo.vtf",
@@ -549,9 +570,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_WorksIfContainsIgnorableExtension_UpdatesPath() =>
+    public void Pakfile_WorksIfContainsIgnorableExtension_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/foo.vtf",
@@ -569,9 +592,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_DifferentExtensionDoesntMatch_ReturnsEmpty() =>
+    public void Pakfile_DifferentExtensionDoesntMatch_ReturnsEmpty()
+    {
         TestPakfile(
             false,
             "materials/test/foo.mdl",
@@ -589,9 +614,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_PartialNameDoesntMatch_ReturnsEmpty() =>
+    public void Pakfile_PartialNameDoesntMatch_ReturnsEmpty()
+    {
         TestPakfile(
             false,
             "materials/test/foo.vtf",
@@ -609,9 +636,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_PartialNameNoQuotesDoesntMatch_ReturnsEmpty() =>
+    public void Pakfile_PartialNameNoQuotesDoesntMatch_ReturnsEmpty()
+    {
         TestPakfile(
             false,
             "materials/test/foo.vtf",
@@ -629,9 +658,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_MatchesBracedPath_UpdatesPath() =>
+    public void Pakfile_MatchesBracedPath_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/{foo}.vtf",
@@ -649,9 +680,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_MatchesBracedPathNoQuotes_UpdatesPath() =>
+    public void Pakfile_MatchesBracedPathNoQuotes_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/{foo}.vtf",
@@ -669,9 +702,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_MatchesPathWithSpaces_UpdatesPath() =>
+    public void Pakfile_MatchesPathWithSpaces_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/foo baz.vtf",
@@ -689,11 +724,13 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     // This is weird behaviour that we'd probably rather avoid, but requires a lot
     // more KV1 parsing to avoid, keeping this test for clarify.
     [Test]
-    public void Pakfile_PathWithSpacesNoQuotes_UpdatesPath() =>
+    public void Pakfile_PathWithSpacesNoQuotes_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/foo bar.vtf",
@@ -711,9 +748,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_WithMultipleSpacesNoQuotes_UpdatesPath() =>
+    public void Pakfile_WithMultipleSpacesNoQuotes_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/foo.vtf",
@@ -731,9 +770,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_NoQuotesWithDirectory_ReturnsEmpty() =>
+    public void Pakfile_NoQuotesWithDirectory_ReturnsEmpty()
+    {
         TestPakfile(
             false,
             "materials/test/foo.vtf",
@@ -751,9 +792,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_CRLF_UpdatesPath() =>
+    public void Pakfile_CRLF_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/foo.vtf",
@@ -771,9 +814,11 @@ public class PakFileLumpRefactoringTests
             }
             """.Replace("\n", "\r\n")
         );
+    }
 
     [Test]
-    public void Pakfile_NoQuotesCRLF_UpdatesPath() =>
+    public void Pakfile_NoQuotesCRLF_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/foo.vtf",
@@ -791,9 +836,11 @@ public class PakFileLumpRefactoringTests
             }
             """.Replace("\n", "\r\n")
         );
+    }
 
     [Test]
-    public void Pakfile_NoQuotesMultipleSpaces_UpdatesPath() =>
+    public void Pakfile_NoQuotesMultipleSpaces_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/foo.vtf",
@@ -811,9 +858,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_NoQuotesTabChar_UpdatesPath() =>
+    public void Pakfile_NoQuotesTabChar_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/foo.vtf",
@@ -831,9 +880,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_NoQuotesCombinedTabsAndSpaces_UpdatesPath() =>
+    public void Pakfile_NoQuotesCombinedTabsAndSpaces_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/foo.vtf",
@@ -851,9 +902,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_MaterialsMaterials_UpdatesPath() =>
+    public void Pakfile_MaterialsMaterials_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/materials/test/foo.vtf",
@@ -871,9 +924,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_CommentsInFile_PreservesComments() =>
+    public void Pakfile_CommentsInFile_PreservesComments()
+    {
         TestPakfile(
             true,
             "materials/test/foo.vtf",
@@ -897,9 +952,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_MatchBackslash_UpdatesPath() =>
+    public void Pakfile_MatchBackslash_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/foo.vtf",
@@ -917,9 +974,11 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     [Test]
-    public void Pakfile_MixedSeparators_UpdatesPath() =>
+    public void Pakfile_MixedSeparators_UpdatesPath()
+    {
         TestPakfile(
             true,
             "materials/test/foo/baz.vtf",
@@ -937,6 +996,7 @@ public class PakFileLumpRefactoringTests
             }
             """
         );
+    }
 
     private static void TestPakfile(
         bool shouldChange,

--- a/src/Lumper.Test/StripperConfigTest.cs
+++ b/src/Lumper.Test/StripperConfigTest.cs
@@ -26,7 +26,10 @@ public class StripperConfigTests
     }
 
     [TearDown]
-    public void TearDown() => _bspFile.Dispose();
+    public void TearDown()
+    {
+        _bspFile.Dispose();
+    }
 
     [Test]
     public void TestAddBlock()
@@ -495,6 +498,8 @@ public class StripperConfigTests
         _entityLump.Data.Add(entity);
     }
 
-    private static string? GetPropertyValue(Entity entity, string key) =>
-        entity.Properties.FirstOrDefault(p => p.Key == key)?.ValueString;
+    private static string? GetPropertyValue(Entity entity, string key)
+    {
+        return entity.Properties.FirstOrDefault(p => p.Key == key)?.ValueString;
+    }
 }

--- a/src/Lumper.UI/App.axaml.cs
+++ b/src/Lumper.UI/App.axaml.cs
@@ -13,7 +13,10 @@ using ReactiveUI;
 
 public class App : Application
 {
-    public override void Initialize() => AvaloniaXamlLoader.Load(this);
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
 
     public override void OnFrameworkInitializationCompleted()
     {

--- a/src/Lumper.UI/Controls/ClearableTextBox.axaml.cs
+++ b/src/Lumper.UI/Controls/ClearableTextBox.axaml.cs
@@ -29,7 +29,13 @@ public partial class ClearableTextBox : UserControl
         set => SetValue(WatermarkProperty, value);
     }
 
-    public ClearableTextBox() => InitializeComponent();
+    public ClearableTextBox()
+    {
+        InitializeComponent();
+    }
 
-    private void ClearButton_OnClick(object? sender, RoutedEventArgs e) => Text = string.Empty;
+    private void ClearButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        Text = string.Empty;
+    }
 }

--- a/src/Lumper.UI/Converters/BitmapAssetValueConverter.cs
+++ b/src/Lumper.UI/Converters/BitmapAssetValueConverter.cs
@@ -70,6 +70,11 @@ public class BitmapAssetValueConverter : IValueConverter
         }
     }
 
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        new BindingNotification(new ArgumentOutOfRangeException(nameof(value)), BindingErrorType.DataValidationError);
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return new BindingNotification(
+            new ArgumentOutOfRangeException(nameof(value)),
+            BindingErrorType.DataValidationError
+        );
+    }
 }

--- a/src/Lumper.UI/Converters/FileSizeConverter.cs
+++ b/src/Lumper.UI/Converters/FileSizeConverter.cs
@@ -21,17 +21,24 @@ public class FileSizeConverter : IValueConverter
         return FormattedFileSize(convertedSize);
     }
 
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
         throw new NotSupportedException();
+    }
 
-    public static string FormattedFileSize(double size) =>
-        size switch
+    public static string FormattedFileSize(double size)
+    {
+        return size switch
         {
             < 1024 => $"{size:N0} bytes",
             < 1024 * 1024 => $"{Math.Ceiling(size / 1024 * 10) / 10:N1} KB",
             < 1024 * 1024 * 1024 => $"{Math.Ceiling(size / 1024 / 1024 * 10) / 10:N1} MB",
             _ => $"{Math.Ceiling(size / 1024 / 1024 / 1024 * 10) / 10:N1} GB",
         };
+    }
 
-    public static string FormattedFileSize(int size) => FormattedFileSize((double)size);
+    public static string FormattedFileSize(int size)
+    {
+        return FormattedFileSize((double)size);
+    }
 }

--- a/src/Lumper.UI/Converters/JobStatusConverter.cs
+++ b/src/Lumper.UI/Converters/JobStatusConverter.cs
@@ -31,6 +31,11 @@ public class JobStatusConverter : IValueConverter
         };
     }
 
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        new BindingNotification(new ArgumentOutOfRangeException(nameof(value)), BindingErrorType.DataValidationError);
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return new BindingNotification(
+            new ArgumentOutOfRangeException(nameof(value)),
+            BindingErrorType.DataValidationError
+        );
+    }
 }

--- a/src/Lumper.UI/Converters/PercentConverter.cs
+++ b/src/Lumper.UI/Converters/PercentConverter.cs
@@ -11,9 +11,13 @@ public class PercentConverter : IValueConverter
 {
     public static PercentConverter Instance { get; } = new();
 
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        $"{(int)System.Convert.ToDouble(value, CultureInfo.InvariantCulture)}%";
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return $"{(int)System.Convert.ToDouble(value, CultureInfo.InvariantCulture)}%";
+    }
 
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
         throw new NotSupportedException();
+    }
 }

--- a/src/Lumper.UI/Program.cs
+++ b/src/Lumper.UI/Program.cs
@@ -38,8 +38,10 @@ internal sealed class Program
     }
 
     // Avalonia configuration, don't remove; also used by visual designer.
-    private static AppBuilder BuildAvaloniaApp() =>
-        AppBuilder.Configure<App>().UsePlatformDetect().LogToTrace().UseReactiveUI();
+    private static AppBuilder BuildAvaloniaApp()
+    {
+        return AppBuilder.Configure<App>().UsePlatformDetect().LogToTrace().UseReactiveUI();
+    }
 
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 

--- a/src/Lumper.UI/Services/BspService.cs
+++ b/src/Lumper.UI/Services/BspService.cs
@@ -164,7 +164,10 @@ public sealed class BspService : ReactiveObject, IDisposable
     // Initial subject to mark BSP changes, can't get RaisePropertyChanged(nameof(BspFile)) to work
     private readonly Subject<BspFile?> _bspSubject = new();
 
-    private void OnBspChanged() => _bspSubject.OnNext(BspFile);
+    private void OnBspChanged()
+    {
+        _bspSubject.OnNext(BspFile);
+    }
 
     /// <summary>
     /// Load a BSP file from a system file
@@ -317,7 +320,10 @@ public sealed class BspService : ReactiveObject, IDisposable
     /// <summary>
     /// Save the currently loaded BSP to it's original file path
     /// </summary>
-    public async Task<bool> Save() => await Save(null);
+    public async Task<bool> Save()
+    {
+        return await Save(null);
+    }
 
     /// <summary>
     /// Save the currently loaded BSP to the given system file
@@ -415,7 +421,8 @@ public sealed class BspService : ReactiveObject, IDisposable
     /// <summary>
     /// Writes a JSON summary of the file out to {filename}.json
     /// </summary>
-    public void JsonDump(IStorageFile file) =>
+    public void JsonDump(IStorageFile file)
+    {
         Observable.Start(
             () =>
                 BspFile?.JsonDump(
@@ -427,6 +434,7 @@ public sealed class BspService : ReactiveObject, IDisposable
                 ),
             RxApp.TaskpoolScheduler
         );
+    }
 
     /// <summary>
     /// Mark the currently loaded BSP file as modified

--- a/src/Lumper.UI/Services/GameSyncService.cs
+++ b/src/Lumper.UI/Services/GameSyncService.cs
@@ -46,11 +46,15 @@ public sealed class GameSyncService : ReactiveObject, IDisposable
     // Very large (1MB) message size so we never have to handle multi-frame messages. Same constant in C++.
     private const uint MaxMessageLength = 1024 * 1024;
 
-    private GameSyncService() =>
+    private GameSyncService()
+    {
         this.WhenAnyValue(x => x.Status).Select(x => x == SyncStatus.Connected).ToPropertyEx(this, x => x.Connected);
+    }
 
-    public void TeleportToOrigin(string origin) =>
+    public void TeleportToOrigin(string origin)
+    {
         _ = PostMessage(new Message { Type = MessageType.CTS_TeleportToLocation, Content = origin });
+    }
 
     public void ToggleConnection()
     {
@@ -231,5 +235,8 @@ public sealed class GameSyncService : ReactiveObject, IDisposable
         public string MapHash { get; set; } = BspService.Instance.FileHash ?? "";
     }
 
-    public void Dispose() => _client?.Dispose();
+    public void Dispose()
+    {
+        _client?.Dispose();
+    }
 }

--- a/src/Lumper.UI/Services/PageService.cs
+++ b/src/Lumper.UI/Services/PageService.cs
@@ -62,7 +62,8 @@ public sealed class PageService : ReactiveObject
 
     private readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
-    private PageService() =>
+    private PageService()
+    {
         BspService
             .Instance.WhenAnyValue(x => x.BspFile)
             .ObserveOn(RxApp.MainThreadScheduler)
@@ -85,6 +86,7 @@ public sealed class PageService : ReactiveObject
                         pageVm.Reset();
                 }
             });
+    }
 
     public void ViewPage(Page page)
     {
@@ -126,10 +128,19 @@ public sealed class PageService : ReactiveObject
         public bool Ephemeral { get; } = ephemeral;
         private Lazy<T> _lazyWrapper = new();
 
-        public T Get() => _lazyWrapper.Value;
+        public T Get()
+        {
+            return _lazyWrapper.Value;
+        }
 
-        public bool IsLoaded() => _lazyWrapper.IsValueCreated;
+        public bool IsLoaded()
+        {
+            return _lazyWrapper.IsValueCreated;
+        }
 
-        public void Reset() => _lazyWrapper = new Lazy<T>();
+        public void Reset()
+        {
+            _lazyWrapper = new Lazy<T>();
+        }
     }
 }

--- a/src/Lumper.UI/Services/StateService.cs
+++ b/src/Lumper.UI/Services/StateService.cs
@@ -18,7 +18,10 @@ public class StateService : ReactiveObject
     // Nasty public ctor needed for RxApp.SuspensionHost.CreateNewAppState
     // `() => StateService.Instance` seems to result in multiple instances
     // somehow??
-    public StateService() => Instance = this;
+    public StateService()
+    {
+        Instance = this;
+    }
 
     [Reactive]
     public long LastUpdateCheck { get; set; } = 0;

--- a/src/Lumper.UI/Services/UpdaterService.cs
+++ b/src/Lumper.UI/Services/UpdaterService.cs
@@ -80,11 +80,13 @@ public sealed partial class UpdaterService : ReactiveObject
     /// to the Git tag used to build the Github release. For dev builds it's always 0.0.0
     /// </summary>
     /// <exception cref="InvalidProgramException"></exception>
-    public static SemVer GetAssemblyVersion() =>
-        SemVer.Parse(
+    public static SemVer GetAssemblyVersion()
+    {
+        return SemVer.Parse(
             Assembly.GetExecutingAssembly().GetName().Version?.ToString()
                 ?? throw new InvalidProgramException("Could not determine version of current assembly!")
         );
+    }
 
     /// <summary>
     /// Downloads an update for the program, applies it, and then restarts itself with the new version
@@ -313,7 +315,10 @@ public sealed partial class UpdaterService : ReactiveObject
 
         public bool IsDevBuild => Major == 0 && Minor == 0 && Patch == 0;
 
-        public override string ToString() => $"{Major}.{Minor}.{Patch}";
+        public override string ToString()
+        {
+            return $"{Major}.{Minor}.{Patch}";
+        }
 
         public static SemVer Parse(string s)
         {
@@ -346,9 +351,11 @@ public sealed partial class UpdaterService : ReactiveObject
 
         public SemVer Version => SemVer.Parse(TagName);
 
-        public string GetDownloadUrl(string osPrefix) =>
-            Assets.FirstOrDefault(a => a.Name.Contains(osPrefix))?.BrowserDownloadUrl
-            ?? throw new InvalidDataException($"Could not find download link for {osPrefix}");
+        public string GetDownloadUrl(string osPrefix)
+        {
+            return Assets.FirstOrDefault(a => a.Name.Contains(osPrefix))?.BrowserDownloadUrl
+                ?? throw new InvalidDataException($"Could not find download link for {osPrefix}");
+        }
     }
 
     public record GithubAsset

--- a/src/Lumper.UI/ViewLocator.cs
+++ b/src/Lumper.UI/ViewLocator.cs
@@ -17,7 +17,10 @@ public class ViewLocator : IDataTemplate
 
     public static void Register<TViewModel, TView>(Func<TView> factory)
         where TViewModel : ViewModel
-        where TView : Control, IViewFor<TViewModel> => Registration.TryAdd(typeof(TViewModel), factory);
+        where TView : Control, IViewFor<TViewModel>
+    {
+        Registration.TryAdd(typeof(TViewModel), factory);
+    }
 
     public Control Build(object? param)
     {
@@ -30,5 +33,8 @@ public class ViewLocator : IDataTemplate
             : new TextBlock { Text = "Not Found: " + type };
     }
 
-    public bool Match(object? data) => data is ViewModel;
+    public bool Match(object? data)
+    {
+        return data is ViewModel;
+    }
 }

--- a/src/Lumper.UI/ViewModels/LogViewer/LogViewerViewModel.cs
+++ b/src/Lumper.UI/ViewModels/LogViewer/LogViewerViewModel.cs
@@ -19,12 +19,15 @@ public sealed class LogViewerViewModel : ViewModelWithView<LogViewerViewModel, L
     private readonly ReplaySubject<LogMessage> _messageSubject = new();
     public IObservable<LogMessage> Messages => _messageSubject.AsObservable();
 
-    public LogViewerViewModel() =>
+    public LogViewerViewModel()
+    {
         LogManager
             .Setup()
             .LoadConfiguration(builder => builder.ForLogger().WriteToMethodCall((logEvent, _) => AddLog(logEvent)));
+    }
 
-    private void AddLog(LogEventInfo e) =>
+    private void AddLog(LogEventInfo e)
+    {
         _messageSubject.OnNext(
             new LogMessage
             {
@@ -34,8 +37,12 @@ public sealed class LogViewerViewModel : ViewModelWithView<LogViewerViewModel, L
                 Exception = e.Exception,
             }
         );
+    }
 
-    public void Dispose() => _messageSubject.Dispose();
+    public void Dispose()
+    {
+        _messageSubject.Dispose();
+    }
 }
 
 public record LogMessage

--- a/src/Lumper.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Lumper.UI/ViewModels/MainWindowViewModel.cs
@@ -187,7 +187,10 @@ public class MainWindowViewModel : ViewModel
         BspService.Instance.CloseCurrentBsp();
     }
 
-    public void ExitCommand() => Program.MainWindow.Close();
+    public void ExitCommand()
+    {
+        Program.MainWindow.Close();
+    }
 
     public void BspInfoCommand()
     {
@@ -213,13 +216,17 @@ public class MainWindowViewModel : ViewModel
             Program.Desktop.Shutdown();
     }
 
-    private static Task<bool> ShowUnsavedChangesDialog(string message) =>
-        MessageBoxManager
+    private static Task<bool> ShowUnsavedChangesDialog(string message)
+    {
+        return MessageBoxManager
             .GetMessageBoxStandard("Unsaved changes", message, ButtonEnum.YesNo)
             .ShowWindowDialogAsync(Program.MainWindow)
             .ContinueWith(result => result.Result == ButtonResult.Yes);
+    }
 
-    private static FilePickerFileType[] GenerateBspFileFilter() =>
+    private static FilePickerFileType[] GenerateBspFileFilter()
+    {
+        return
         [
             new("BSP Files")
             {
@@ -232,4 +239,5 @@ public class MainWindowViewModel : ViewModel
             },
             new("All Files") { Patterns = ["*"] },
         ];
+    }
 }

--- a/src/Lumper.UI/ViewModels/Pages/EntityEditor/EntityEditorViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/EntityEditor/EntityEditorViewModel.cs
@@ -301,7 +301,10 @@ public sealed class EntityEditorViewModel : ViewModelWithView<EntityEditorViewMo
             Tabs.Remove(tab);
     }
 
-    public void CloseSelectedTab() => CloseTab(SelectedTab);
+    public void CloseSelectedTab()
+    {
+        CloseTab(SelectedTab);
+    }
 
     public void CloseTab(EntityEditorTabViewModel? tab)
     {

--- a/src/Lumper.UI/ViewModels/Pages/EntityReview/EntityReviewViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/EntityReview/EntityReviewViewModel.cs
@@ -25,7 +25,8 @@ public sealed class EntityReviewViewModel : ViewModelWithView<EntityReviewViewMo
     private readonly ReadOnlyObservableCollection<EntityReviewResult> _results;
     public ReadOnlyObservableCollection<EntityReviewResult> Results => _results;
 
-    public EntityReviewViewModel() =>
+    public EntityReviewViewModel()
+    {
         // Map tuple of ent lumps (handles BSP changes) and rulesets (handle rule file changes)
         // into changesets of EntityViewResults, where we group every entity into a result based
         // on classname. Switch() unsubscribes the previous changeset pipeline whenever tuple
@@ -50,6 +51,7 @@ public sealed class EntityReviewViewModel : ViewModelWithView<EntityReviewViewMo
             .Switch()
             .Bind(out _results)
             .Subscribe();
+    }
 
     public void SwitchToEntityEditor(string classname)
     {
@@ -74,13 +76,15 @@ public sealed class EntityReviewViewModel : ViewModelWithView<EntityReviewViewMo
         RulesFilePath = result[0].Path.LocalPath;
     }
 
-    private static FilePickerOpenOptions GenerateFilePickerOptions() =>
-        new()
+    private static FilePickerOpenOptions GenerateFilePickerOptions()
+    {
+        return new()
         {
             Title = "Pick Entity Rule File",
             AllowMultiple = false,
             FileTypeFilter = [new FilePickerFileType("Entity Rule File") { Patterns = ["*.json"] }],
         };
+    }
 
     public class EntityReviewResult
     {

--- a/src/Lumper.UI/ViewModels/Pages/Jobs/JobsViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/Jobs/JobsViewModel.cs
@@ -65,8 +65,9 @@ public class JobsViewModel : ViewModelWithView<JobsViewModel, JobsView>
 
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-    public static JobViewModel CreateJobViewModel(IJob job) =>
-        job switch
+    public static JobViewModel CreateJobViewModel(IJob job)
+    {
+        return job switch
         {
             StripperFileJob stripperFile => new StripperFileJobViewModel(stripperFile),
             StripperTextJob stripperText => new StripperTextJobViewModel(stripperText),
@@ -75,6 +76,7 @@ public class JobsViewModel : ViewModelWithView<JobsViewModel, JobsView>
             RemoveAssetJob removeAsset => new RemoveAssetJobViewModel(removeAsset),
             _ => throw new ArgumentException("Invalid job"),
         };
+    }
 
     public async Task Run()
     {
@@ -134,9 +136,15 @@ public class JobsViewModel : ViewModelWithView<JobsViewModel, JobsView>
         Down = 1,
     }
 
-    public void MoveSelectedUp() => MoveSelectedInDirection(MoveDir.Up);
+    public void MoveSelectedUp()
+    {
+        MoveSelectedInDirection(MoveDir.Up);
+    }
 
-    public void MoveSelectedDown() => MoveSelectedInDirection(MoveDir.Down);
+    public void MoveSelectedDown()
+    {
+        MoveSelectedInDirection(MoveDir.Down);
+    }
 
     private void MoveSelectedInDirection(MoveDir dir)
     {
@@ -224,9 +232,12 @@ public class JobsViewModel : ViewModelWithView<JobsViewModel, JobsView>
         SaveWorkflow(await result.OpenWriteAsync());
     }
 
-    private static FilePickerFileType[] GenerateJsonFileFilter() =>
+    private static FilePickerFileType[] GenerateJsonFileFilter()
+    {
+        return
         [
             new FilePickerFileType("JSON Files") { Patterns = ["*.json"] },
             new FilePickerFileType("All Files") { Patterns = ["*"] },
         ];
+    }
 }

--- a/src/Lumper.UI/ViewModels/Pages/Jobs/ReplaceTextureJobViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/Jobs/ReplaceTextureJobViewModel.cs
@@ -41,9 +41,15 @@ public sealed class ReplaceTextureJobViewModel : JobViewModel, IDisposable
         _source.Connect().Transform(x => x.Model).ToCollection().Subscribe(x => job.Replacers = [.. x]);
     }
 
-    public void Add() => _source.Add(new ReplacerViewModel());
+    public void Add()
+    {
+        _source.Add(new ReplacerViewModel());
+    }
 
-    public void Delete(ReplacerViewModel replacer) => _source.Remove(replacer);
+    public void Delete(ReplacerViewModel replacer)
+    {
+        _source.Remove(replacer);
+    }
 
     public class ReplacerViewModel : ViewModel
     {
@@ -67,5 +73,8 @@ public sealed class ReplaceTextureJobViewModel : JobViewModel, IDisposable
         }
     }
 
-    public void Dispose() => _source.Dispose();
+    public void Dispose()
+    {
+        _source.Dispose();
+    }
 }

--- a/src/Lumper.UI/ViewModels/Pages/Jobs/StripperFileJobViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/Jobs/StripperFileJobViewModel.cs
@@ -37,11 +37,13 @@ public class StripperFileJobViewModel : JobViewModel
         ConfigPath = result[0].Path.LocalPath;
     }
 
-    private static FilePickerOpenOptions GenerateFilePickerOptions() =>
-        new()
+    private static FilePickerOpenOptions GenerateFilePickerOptions()
+    {
+        return new()
         {
             Title = "Pick Stripper Config",
             AllowMultiple = false,
             FileTypeFilter = [new FilePickerFileType("Stripper Config") { Patterns = ["*.cfg"] }],
         };
+    }
 }

--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
@@ -37,7 +37,8 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
 
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-    public PakfileExplorerViewModel() =>
+    public PakfileExplorerViewModel()
+    {
         BspService
             .Instance.WhenAnyValue(x => x.PakfileLumpViewModel)
             .ObserveOn(RxApp.MainThreadScheduler)
@@ -113,6 +114,7 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
                             : null
                     );
             });
+    }
 
     // Null here is fine, just closes RHS pane.
     private void SetActiveFile(Node? node)
@@ -130,13 +132,25 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
         ActiveFile = node.Leaf;
     }
 
-    public void Unsort() => DataGridSource?.Sort(null);
+    public void Unsort()
+    {
+        DataGridSource?.Sort(null);
+    }
 
-    public void ExpandAll() => DataGridSource?.ExpandAll();
+    public void ExpandAll()
+    {
+        DataGridSource?.ExpandAll();
+    }
 
-    public void CollapseAll() => DataGridSource?.CollapseAll();
+    public void CollapseAll()
+    {
+        DataGridSource?.CollapseAll();
+    }
 
-    public void OnMoveFiles() => Observable.Start(PushTreeChangesToEntries, RxApp.MainThreadScheduler);
+    public void OnMoveFiles()
+    {
+        Observable.Start(PushTreeChangesToEntries, RxApp.MainThreadScheduler);
+    }
 
     // Stores current treegrid selection in out var returns if it's valid,
     // including if only one is selected if single is true
@@ -485,8 +499,9 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
         string inputLabel,
         string buttonLabel,
         string defaultInput = ""
-    ) =>
-        MessageBoxManager.GetMessageBoxCustom(
+    )
+    {
+        return MessageBoxManager.GetMessageBoxCustom(
             new MessageBoxCustomParams
             {
                 ContentTitle = title,
@@ -501,8 +516,12 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
                 ],
             }
         );
+    }
 
-    private static Task<string> ShowMessageBox(IMsBox<string> msBox) => msBox.ShowWindowDialogAsync(Program.MainWindow);
+    private static Task<string> ShowMessageBox(IMsBox<string> msBox)
+    {
+        return msBox.ShowWindowDialogAsync(Program.MainWindow);
+    }
 
     private static async ValueTask<IStorageFolder?> PickFolder(string title = "Pick folder")
     {
@@ -516,8 +535,10 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
         return result[0];
     }
 
-    private static Task<IReadOnlyList<IStorageFile>> PickFiles(string title = "Pick file(s)") =>
-        Program.MainWindow.StorageProvider.OpenFilePickerAsync(
+    private static Task<IReadOnlyList<IStorageFile>> PickFiles(string title = "Pick file(s)")
+    {
+        return Program.MainWindow.StorageProvider.OpenFilePickerAsync(
             new FilePickerOpenOptions { Title = title, AllowMultiple = true }
         );
+    }
 }

--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileTreeViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileTreeViewModel.cs
@@ -72,7 +72,10 @@ public class PakfileTreeViewModel
         }
     }
 
-    public IEnumerable<Node> EnumerateLeaves() => Root.EnumerateLeaves();
+    public IEnumerable<Node> EnumerateLeaves()
+    {
+        return Root.EnumerateLeaves();
+    }
 }
 
 public class PakfileTreeNodeViewModel : ViewModel
@@ -96,7 +99,10 @@ public class PakfileTreeNodeViewModel : ViewModel
 
     public string? Extension => Leaf?.Extension;
 
-    public PakfileTreeNodeViewModel() => Size = Leaf?.UncompressedSize ?? 0;
+    public PakfileTreeNodeViewModel()
+    {
+        Size = Leaf?.UncompressedSize ?? 0;
+    }
 
     // Note that this is the entire path, INCLUDING name.extension
     public PathList Path
@@ -118,9 +124,15 @@ public class PakfileTreeNodeViewModel : ViewModel
 
     public string PathString => string.Join("/", Path);
 
-    public void Add(PakfileEntryViewModel value, PathList path) => AddInternal(value, path);
+    public void Add(PakfileEntryViewModel value, PathList path)
+    {
+        AddInternal(value, path);
+    }
 
-    public void AddDirectory(PathList path) => AddInternal(null, path);
+    public void AddDirectory(PathList path)
+    {
+        AddInternal(null, path);
+    }
 
     private void AddInternal(PakfileEntryViewModel? value, PathList path)
     {
@@ -168,7 +180,10 @@ public class PakfileTreeNodeViewModel : ViewModel
         (Children ??= []).Add(newNode);
     }
 
-    public void RemoveSelf() => Parent?.Children?.Remove(this);
+    public void RemoveSelf()
+    {
+        Parent?.Children?.Remove(this);
+    }
 
     public void RemoveRecursive(PathList path)
     {
@@ -243,10 +258,14 @@ public class PakfileTreeNodeViewModel : ViewModel
         return previous!;
     }
 
-    public void RecalculateSize() => Size = Children?.Sum(child => child.Size) ?? 0;
+    public void RecalculateSize()
+    {
+        Size = Children?.Sum(child => child.Size) ?? 0;
+    }
 
-    public static Comparison<Node?> SortAscending<T>(Func<Node, T> selector) =>
-        (x, y) =>
+    public static Comparison<Node?> SortAscending<T>(Func<Node, T> selector)
+    {
+        return (x, y) =>
         {
             if (x is null && y is null)
                 return 0;
@@ -256,9 +275,11 @@ public class PakfileTreeNodeViewModel : ViewModel
                 return 1;
             return Comparer<T>.Default.Compare(selector(x), selector(y));
         };
+    }
 
-    public static Comparison<Node?> SortDescending<T>(Func<Node, T> selector) =>
-        (x, y) =>
+    public static Comparison<Node?> SortDescending<T>(Func<Node, T> selector)
+    {
+        return (x, y) =>
         {
             if (x is null && y is null)
                 return 0;
@@ -268,4 +289,5 @@ public class PakfileTreeNodeViewModel : ViewModel
                 return -1;
             return Comparer<T>.Default.Compare(selector(y), selector(x));
         };
+    }
 }

--- a/src/Lumper.UI/ViewModels/Shared/Entity/EntityLumpViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Entity/EntityLumpViewModel.cs
@@ -33,7 +33,10 @@ public sealed class EntityLumpViewModel : LumpViewModel
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
     // Required by BspService.LazyLoadLump
-    public EntityLumpViewModel() => throw new NotImplementedException();
+    public EntityLumpViewModel()
+    {
+        throw new NotImplementedException();
+    }
 
     // This class is created the first time something requests this lump from BspService,
     // and discarded when that BSP file is closed.
@@ -48,12 +51,14 @@ public sealed class EntityLumpViewModel : LumpViewModel
         Entities.CountChanged.ObserveOn(RxApp.MainThreadScheduler).ToPropertyEx(this, x => x.EntityCount);
     }
 
-    private void LoadEntityList() =>
+    private void LoadEntityList()
+    {
         Entities.Edit(innerCache =>
         {
             innerCache.Clear();
             innerCache.AddOrUpdate(_entityLump.Data.Select(ent => new EntityViewModel(ent, this)));
         });
+    }
 
     // Note: don't use this for doing large inserts, you'll make the SourceCache fire a billion
     // update notifications. Use .Edit to batch all changes together:
@@ -77,7 +82,8 @@ public sealed class EntityLumpViewModel : LumpViewModel
         MarkAsModified();
     }
 
-    public void RemoveMultiple(IEnumerable<EntityViewModel> entities) =>
+    public void RemoveMultiple(IEnumerable<EntityViewModel> entities)
+    {
         Entities.Edit(innerCache =>
         {
             foreach (EntityViewModel entity in entities)
@@ -86,6 +92,7 @@ public sealed class EntityLumpViewModel : LumpViewModel
                 innerCache.Remove(entity);
             }
         });
+    }
 
     /// <summary>
     /// Get a MemoryStream of the lump, as ASCII text data
@@ -233,5 +240,8 @@ public sealed class EntityLumpViewModel : LumpViewModel
             newEnt.MarkAsModified(); // Probably best to do this last
     }
 
-    public override void Dispose() => Entities.Dispose();
+    public override void Dispose()
+    {
+        Entities.Dispose();
+    }
 }

--- a/src/Lumper.UI/ViewModels/Shared/Entity/EntityPropertyViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Entity/EntityPropertyViewModel.cs
@@ -41,21 +41,29 @@ public abstract class EntityPropertyViewModel(Entity.EntityProperty property, Bs
         }
     }
 
-    public static EntityPropertyViewModel Create(Entity.EntityProperty entityProperty, EntityViewModel parent) =>
-        entityProperty switch
+    public static EntityPropertyViewModel Create(Entity.EntityProperty entityProperty, EntityViewModel parent)
+    {
+        return entityProperty switch
         {
             Entity.EntityProperty<string> sp => new EntityPropertyStringViewModel(sp, parent),
             Entity.EntityProperty<EntityIo> sio => new EntityPropertyIoViewModel(sio, parent),
             _ => throw new ArgumentOutOfRangeException(nameof(entityProperty)),
         };
+    }
 
     public abstract bool MemberwiseEquals(EntityPropertyViewModel other);
 
-    public bool MatchKey(string expr, bool wildcardWrapping) => Key.MatchesSimpleExpression(expr, wildcardWrapping);
+    public bool MatchKey(string expr, bool wildcardWrapping)
+    {
+        return Key.MatchesSimpleExpression(expr, wildcardWrapping);
+    }
 
     public abstract bool MatchValue(string expr, bool wildcardWrapping);
 
-    public void Delete() => ((EntityViewModel)Parent).DeleteProperty(this);
+    public void Delete()
+    {
+        ((EntityViewModel)Parent).DeleteProperty(this);
+    }
 }
 
 public class EntityPropertyStringViewModel(Entity.EntityProperty<string> property, BspNode bspNode)
@@ -80,11 +88,15 @@ public class EntityPropertyStringViewModel(Entity.EntityProperty<string> propert
         }
     }
 
-    public override bool MemberwiseEquals(EntityPropertyViewModel other) =>
-        other is EntityPropertyStringViewModel o && o.Key == Key && o.Value == Value;
+    public override bool MemberwiseEquals(EntityPropertyViewModel other)
+    {
+        return other is EntityPropertyStringViewModel o && o.Key == Key && o.Value == Value;
+    }
 
-    public override bool MatchValue(string expr, bool wildcardWrapping) =>
-        Value.MatchesSimpleExpression(expr, wildcardWrapping);
+    public override bool MatchValue(string expr, bool wildcardWrapping)
+    {
+        return Value.MatchesSimpleExpression(expr, wildcardWrapping);
+    }
 }
 
 // ReSharper disable CompareOfFloatsByEqualityOperator
@@ -179,20 +191,30 @@ public class EntityPropertyIoViewModel(Entity.EntityProperty<EntityIo> property,
         this.RaisePropertyChanged(nameof(DisplayValue));
     }
 
-    public override bool MemberwiseEquals(EntityPropertyViewModel other) =>
-        other is EntityPropertyIoViewModel o
-        && o.Key == Key
-        && o.TargetEntityName == TargetEntityName
-        && o.Input == Input
-        && o.Parameter == Parameter
-        // ReSharper disable once CompareOfFloatsByEqualityOperator
-        && o.Delay == Delay
-        && o.TimesToFire == TimesToFire;
+    public override bool MemberwiseEquals(EntityPropertyViewModel other)
+    {
+        return other is EntityPropertyIoViewModel o
+            && o.Key == Key
+            && o.TargetEntityName == TargetEntityName
+            && o.Input == Input
+            && o.Parameter == Parameter
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
+            && o.Delay == Delay
+            && o.TimesToFire == TimesToFire;
+    }
 
-    public override bool MatchValue(string expr, bool wildcardWrapping) =>
+    public override bool MatchValue(string expr, bool wildcardWrapping)
+    {
         // Match against both comma and space separated values
-        string.Create(CultureInfo.InvariantCulture, $"{TargetEntityName} {Input} {Parameter} {Delay} {TimesToFire}")
-            .MatchesSimpleExpression(expr, wildcardWrapping)
-        || string.Create(CultureInfo.InvariantCulture, $"{TargetEntityName},{Input},{Parameter},{Delay},{TimesToFire}")
-            .MatchesSimpleExpression(expr, wildcardWrapping);
+        return string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"{TargetEntityName} {Input} {Parameter} {Delay} {TimesToFire}"
+                )
+                .MatchesSimpleExpression(expr, wildcardWrapping)
+            || string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"{TargetEntityName},{Input},{Parameter},{Delay},{TimesToFire}"
+                )
+                .MatchesSimpleExpression(expr, wildcardWrapping);
+    }
 }

--- a/src/Lumper.UI/ViewModels/Shared/Entity/EntityViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Entity/EntityViewModel.cs
@@ -62,7 +62,10 @@ public class EntityViewModel : HierarchicalBspNode
         MarkAsModified();
     }
 
-    public void AddString() => AddProperty(new Entity.EntityProperty<string>("newproperty", "newvalue"));
+    public void AddString()
+    {
+        AddProperty(new Entity.EntityProperty<string>("newproperty", "newvalue"));
+    }
 
     public void AddIo()
     {
@@ -85,10 +88,15 @@ public class EntityViewModel : HierarchicalBspNode
         AddProperty(new Entity.EntityProperty<EntityIo>("newproperty", new EntityIo(separator)));
     }
 
-    public string? FindProperty(string key) =>
-        Properties.OfType<EntityPropertyStringViewModel>().FirstOrDefault(x => x.Key == key)?.Value;
+    public string? FindProperty(string key)
+    {
+        return Properties.OfType<EntityPropertyStringViewModel>().FirstOrDefault(x => x.Key == key)?.Value;
+    }
 
-    public void ResetClassname() => Classname = FindProperty("classname")!;
+    public void ResetClassname()
+    {
+        Classname = FindProperty("classname")!;
+    }
 
     public string? Origin => FindProperty("origin");
 
@@ -100,8 +108,10 @@ public class EntityViewModel : HierarchicalBspNode
 
     public string ClassAndTargetname => Targetname is { } tn ? $"{Classname} ({tn})" : Classname;
 
-    public bool MatchClassname(string expr, bool wildcardWrapping) =>
-        _classname?.MatchesSimpleExpression(expr, wildcardWrapping) ?? false;
+    public bool MatchClassname(string expr, bool wildcardWrapping)
+    {
+        return _classname?.MatchesSimpleExpression(expr, wildcardWrapping) ?? false;
+    }
 
     public void TeleportToMe()
     {

--- a/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryTextViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryTextViewModel.cs
@@ -23,7 +23,10 @@ public class PakfileEntryTextViewModel : PakfileEntryViewModel
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
     public PakfileEntryTextViewModel(PakfileEntry entry, BspNode parent)
-        : base(entry, parent) => RegisterView<PakfileEntryTextViewModel, PakfileEntryTextView>();
+        : base(entry, parent)
+    {
+        RegisterView<PakfileEntryTextViewModel, PakfileEntryTextView>();
+    }
 
     public override void Load(CancellationTokenSource? cts = null)
     {

--- a/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryViewModel.cs
@@ -53,13 +53,15 @@ public abstract class PakfileEntryViewModel : HierarchicalBspNode
 
     public virtual void Load(CancellationTokenSource? cts = null) { }
 
-    public static PakfileEntryViewModel Create(PakfileEntry entry, PakfileLumpViewModel parent) =>
-        Path.GetExtension(entry.Key).Equals(".vtf", StringComparison.OrdinalIgnoreCase)
+    public static PakfileEntryViewModel Create(PakfileEntry entry, PakfileLumpViewModel parent)
+    {
+        return Path.GetExtension(entry.Key).Equals(".vtf", StringComparison.OrdinalIgnoreCase)
             ? new PakfileEntryVtfViewModel(entry, parent)
             // Treat anything that isn't a VTF as a text file. If it's not a file we recognise as text,
             // the UI shows a warning, but does allow editing -- may be some file extensions that we
             // don't recognise but are still text.
             : new PakfileEntryTextViewModel(entry, parent);
+    }
 
     public void Rename(string newKey)
     {

--- a/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryVtfViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryVtfViewModel.cs
@@ -167,9 +167,12 @@ public class PakfileEntryVtfViewModel : PakfileEntryViewModel
         SkipMetadata = false,
     };
 
-    private static FilePickerFileType[] GenerateImageFileFilter() =>
+    private static FilePickerFileType[] GenerateImageFileFilter()
+    {
+        return
         [
             new FilePickerFileType("Image files") { Patterns = ["*.bmp", "*.jpeg", "*.jpg", "*.png"] },
             new FilePickerFileType("All files") { Patterns = ["*"] },
         ];
+    }
 }

--- a/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileLumpViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileLumpViewModel.cs
@@ -16,7 +16,10 @@ public sealed class PakfileLumpViewModel : LumpViewModel
 
     public SourceCache<PakfileEntryViewModel, string> Entries { get; } = new(entry => entry.Key);
 
-    public PakfileLumpViewModel() => throw new NotImplementedException();
+    public PakfileLumpViewModel()
+    {
+        throw new NotImplementedException();
+    }
 
     public PakfileLumpViewModel(BspFile bsp)
     {
@@ -27,7 +30,8 @@ public sealed class PakfileLumpViewModel : LumpViewModel
         PullChangesFromModel(); // Initializes everything
     }
 
-    public override void PullChangesFromModel() =>
+    public override void PullChangesFromModel()
+    {
         Entries.Edit(updater =>
         {
             foreach (PakfileEntry model in _pakfile.Entries)
@@ -52,6 +56,7 @@ public sealed class PakfileLumpViewModel : LumpViewModel
                     updater.Remove(entry);
             }
         });
+    }
 
     public PakfileEntryViewModel AddEntry(
         string key,

--- a/src/Lumper.UI/ViewModels/Shared/Vtf/VtfFileViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Vtf/VtfFileViewModel.cs
@@ -134,7 +134,8 @@ public class VtfFileViewModel(PakfileEntryVtfViewModel pakfileEntry) : ViewModel
         return Image.LoadPixelData<Rgba32>(rgba.AsSpan(), (int)ImageWidth, (int)ImageHeight);
     }
 
-    public async Task SetImageData(Image<Rgba32> image, uint frame, uint face, uint slice, uint mipmapLevel) =>
+    public async Task SetImageData(Image<Rgba32> image, uint frame, uint face, uint slice, uint mipmapLevel)
+    {
         await VtfLibQueue.Run(() =>
         {
             Prepare();
@@ -155,8 +156,10 @@ public class VtfFileViewModel(PakfileEntryVtfViewModel pakfileEntry) : ViewModel
             VTFFile.ImageSetData(frame, face, slice, mipmapLevel, vtfImageData);
             SaveVtf();
         });
+    }
 
-    public async Task SetNewImage(Image<Rgba32> image) =>
+    public async Task SetNewImage(Image<Rgba32> image)
+    {
         await VtfLibQueue.Run(() =>
         {
             Prepare();
@@ -182,6 +185,7 @@ public class VtfFileViewModel(PakfileEntryVtfViewModel pakfileEntry) : ViewModel
 
             SaveVtf();
         });
+    }
 
     private void Prepare()
     {
@@ -278,9 +282,13 @@ public class VtfFileViewModel(PakfileEntryVtfViewModel pakfileEntry) : ViewModel
         private static readonly Lock Lock = new();
         private static bool _isRunning;
 
-        public static Task Run(Action fn) => Run(fn, null);
+        public static Task Run(Action fn)
+        {
+            return Run(fn, null);
+        }
 
-        public static async Task Run(Action fn, CancellationTokenSource? cts) =>
+        public static async Task Run(Action fn, CancellationTokenSource? cts)
+        {
             await Run<object>(
                 () =>
                 {
@@ -289,8 +297,12 @@ public class VtfFileViewModel(PakfileEntryVtfViewModel pakfileEntry) : ViewModel
                 },
                 cts
             );
+        }
 
-        public static Task<T> Run<T>(Func<object> fn) => Run<T>(fn, null)!;
+        public static Task<T> Run<T>(Func<object> fn)
+        {
+            return Run<T>(fn, null)!;
+        }
 
         public static async Task<T?> Run<T>(Func<object> fn, CancellationTokenSource? cts)
         {

--- a/src/Lumper.UI/ViewModels/ViewModel.cs
+++ b/src/Lumper.UI/ViewModels/ViewModel.cs
@@ -12,8 +12,10 @@ public class ViewModel : ReactiveObject
 {
     protected void RegisterView<TViewModel, TView>()
         where TViewModel : ViewModel
-        where TView : Control, IViewFor<TViewModel>, new() =>
+        where TView : Control, IViewFor<TViewModel>, new()
+    {
         ViewLocator.Register<TViewModel, TView>(() => new TView());
+    }
 };
 
 /// <summary>
@@ -23,5 +25,8 @@ public class ViewModelWithView<TViewModel, TView> : ViewModel
     where TViewModel : ViewModel
     where TView : Control, IViewFor<TViewModel>, new()
 {
-    protected ViewModelWithView() => ViewLocator.Register<TViewModel, TView>(() => new TView());
+    protected ViewModelWithView()
+    {
+        ViewLocator.Register<TViewModel, TView>(() => new TView());
+    }
 }

--- a/src/Lumper.UI/Views/LogViewer/LogViewerView.axaml.cs
+++ b/src/Lumper.UI/Views/LogViewer/LogViewerView.axaml.cs
@@ -149,7 +149,13 @@ public partial class LogViewerView : ReactiveUserControl<LogViewerViewModel>
         { LogLevel.Off, Brushes.Gray },
     };
 
-    private void ScrollToBottom(object? _, RoutedEventArgs __) => ScrollToBottom();
+    private void ScrollToBottom(object? _, RoutedEventArgs __)
+    {
+        ScrollToBottom();
+    }
 
-    private void ScrollToBottom() => ScrollViewer.ScrollToEnd();
+    private void ScrollToBottom()
+    {
+        ScrollViewer.ScrollToEnd();
+    }
 }

--- a/src/Lumper.UI/Views/MainWindow.axaml.cs
+++ b/src/Lumper.UI/Views/MainWindow.axaml.cs
@@ -73,7 +73,8 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
         });
     }
 
-    private void PopulateRecentFilesList() =>
+    private void PopulateRecentFilesList()
+    {
         RecentFiles.ItemsSource = StateService
             .Instance.RecentFiles.Select(path =>
             {
@@ -91,6 +92,7 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
             })
             .Reverse()
             .ToList();
+    }
 
     // ReSharper disable once AsyncVoidMethod - Needed for event binding
     private async void Window_OnClosing(object? _, WindowClosingEventArgs e)
@@ -115,9 +117,11 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
         await ViewModel!.OpenDragDropped(files);
     }
 
-    private List<IStorageFile> FilterDraggedBspFiles(DragEventArgs e) =>
-        e.Data.GetFiles()
-            ?.OfType<IStorageFile>()
-            .Where(file => file.Name.EndsWith(".bsp", StringComparison.Ordinal))
-            .ToList() ?? [];
+    private List<IStorageFile> FilterDraggedBspFiles(DragEventArgs e)
+    {
+        return e.Data.GetFiles()
+                ?.OfType<IStorageFile>()
+                .Where(file => file.Name.EndsWith(".bsp", StringComparison.Ordinal))
+                .ToList() ?? [];
+    }
 }

--- a/src/Lumper.UI/Views/Pages/EntityEditor/EntityEditorView.axaml.cs
+++ b/src/Lumper.UI/Views/Pages/EntityEditor/EntityEditorView.axaml.cs
@@ -9,11 +9,20 @@ using Lumper.UI.ViewModels.Shared.Entity;
 
 public partial class EntityEditorView : ReactiveUserControl<EntityEditorViewModel>
 {
-    public EntityEditorView() => InitializeComponent();
+    public EntityEditorView()
+    {
+        InitializeComponent();
+    }
 
-    private void SelectAll(object? sender, RoutedEventArgs e) => EntityList?.SelectAll();
+    private void SelectAll(object? sender, RoutedEventArgs e)
+    {
+        EntityList?.SelectAll();
+    }
 
-    private void EntityList_OnSelectionChanged(object? _, SelectionChangedEventArgs __) => OpenSelectedListItem();
+    private void EntityList_OnSelectionChanged(object? _, SelectionChangedEventArgs __)
+    {
+        OpenSelectedListItem();
+    }
 
     private void OpenSelectedListItem()
     {

--- a/src/Lumper.UI/Views/Pages/EntityReview/EntityReviewView.axaml.cs
+++ b/src/Lumper.UI/Views/Pages/EntityReview/EntityReviewView.axaml.cs
@@ -5,5 +5,8 @@ using Lumper.UI.ViewModels.Pages.EntityReview;
 
 public partial class EntityReviewView : ReactiveUserControl<EntityReviewViewModel>
 {
-    public EntityReviewView() => InitializeComponent();
+    public EntityReviewView()
+    {
+        InitializeComponent();
+    }
 }

--- a/src/Lumper.UI/Views/Pages/Jobs/JobView.axaml.cs
+++ b/src/Lumper.UI/Views/Pages/Jobs/JobView.axaml.cs
@@ -25,7 +25,10 @@ public partial class JobView : UserControl
         set => SetValue(MainContentProperty, value);
     }
 
-    public JobView() => InitializeComponent();
+    public JobView()
+    {
+        InitializeComponent();
+    }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {

--- a/src/Lumper.UI/Views/Pages/Jobs/JobsView.axaml.cs
+++ b/src/Lumper.UI/Views/Pages/Jobs/JobsView.axaml.cs
@@ -5,5 +5,8 @@ using Lumper.UI.ViewModels.Pages.Jobs;
 
 public partial class JobsView : ReactiveUserControl<JobsViewModel>
 {
-    public JobsView() => InitializeComponent();
+    public JobsView()
+    {
+        InitializeComponent();
+    }
 }

--- a/src/Lumper.UI/Views/Pages/Jobs/RemoveAssetJobView.axaml.cs
+++ b/src/Lumper.UI/Views/Pages/Jobs/RemoveAssetJobView.axaml.cs
@@ -5,5 +5,8 @@ using Lumper.UI.ViewModels.Pages.Jobs;
 
 public partial class RemoveAssetJobView : ReactiveUserControl<RemoveAssetJobViewModel>
 {
-    public RemoveAssetJobView() => InitializeComponent();
+    public RemoveAssetJobView()
+    {
+        InitializeComponent();
+    }
 }

--- a/src/Lumper.UI/Views/Pages/Jobs/ReplaceTextureJobView.axaml.cs
+++ b/src/Lumper.UI/Views/Pages/Jobs/ReplaceTextureJobView.axaml.cs
@@ -5,5 +5,8 @@ using Lumper.UI.ViewModels.Pages.Jobs;
 
 public partial class ReplaceTextureJobView : ReactiveUserControl<ReplaceTextureJobViewModel>
 {
-    public ReplaceTextureJobView() => InitializeComponent();
+    public ReplaceTextureJobView()
+    {
+        InitializeComponent();
+    }
 }

--- a/src/Lumper.UI/Views/Pages/Jobs/RunExternalToolJobView.axaml.cs
+++ b/src/Lumper.UI/Views/Pages/Jobs/RunExternalToolJobView.axaml.cs
@@ -5,5 +5,8 @@ using Lumper.UI.ViewModels.Pages.Jobs;
 
 public partial class RunExternalToolJobView : ReactiveUserControl<RunExternalToolJobViewModel>
 {
-    public RunExternalToolJobView() => InitializeComponent();
+    public RunExternalToolJobView()
+    {
+        InitializeComponent();
+    }
 }

--- a/src/Lumper.UI/Views/Pages/Jobs/StripperFileJobView.axaml.cs
+++ b/src/Lumper.UI/Views/Pages/Jobs/StripperFileJobView.axaml.cs
@@ -5,5 +5,8 @@ using Lumper.UI.ViewModels.Pages.Jobs;
 
 public partial class StripperFileJobView : ReactiveUserControl<StripperFileJobViewModel>
 {
-    public StripperFileJobView() => InitializeComponent();
+    public StripperFileJobView()
+    {
+        InitializeComponent();
+    }
 }

--- a/src/Lumper.UI/Views/Pages/VtfBrowser/VtfBrowserView.axaml.cs
+++ b/src/Lumper.UI/Views/Pages/VtfBrowser/VtfBrowserView.axaml.cs
@@ -5,5 +5,8 @@ using Lumper.UI.ViewModels.Pages.VtfBrowser;
 
 public partial class VtfBrowserView : ReactiveUserControl<VtfBrowserViewModel>
 {
-    public VtfBrowserView() => InitializeComponent();
+    public VtfBrowserView()
+    {
+        InitializeComponent();
+    }
 }

--- a/src/Lumper.UI/Views/Shared/Pakfile/PakfileEntryVtfView.axaml.cs
+++ b/src/Lumper.UI/Views/Shared/Pakfile/PakfileEntryVtfView.axaml.cs
@@ -6,7 +6,13 @@ using Lumper.UI.ViewModels.Shared.Pakfile;
 
 public partial class PakfileEntryVtfView : ReactiveUserControl<PakfileEntryVtfViewModel>
 {
-    public PakfileEntryVtfView() => InitializeComponent();
+    public PakfileEntryVtfView()
+    {
+        InitializeComponent();
+    }
 
-    private void Image_OnPointerPressed(object? _, PointerPressedEventArgs __) => ViewModel!.OpenVtfImageWindow();
+    private void Image_OnPointerPressed(object? _, PointerPressedEventArgs __)
+    {
+        ViewModel!.OpenVtfImageWindow();
+    }
 }


### PR DESCRIPTION
Sorry, random styling/linter thing. Had expression-bodied methods/ctors enabled since it was default in `dotnet format` and I like the conciseness in some cases, but in some classes it's feeling really jumbled, especially constructors. Also don't like using two different syntaxes for methods depending on not if the method contains a single expression or not.

This PR just changes the rules in .editorconfig, then runs `dotnet format style` and csharpier, took 2 minutes.

Also yeah every time I look at the copyright in this editorconfig I get annoyed, we never even based that heavily off of it in the first place, I just don't care.