### PR TITLE
Remove asset job fix and tests

### DIFF
--- a/src/Lumper.Lib/Jobs/RemoveAssetJob.cs
+++ b/src/Lumper.Lib/Jobs/RemoveAssetJob.cs
@@ -33,7 +33,7 @@ public class RemoveAssetJob : Job, IJob
 
     public override bool Run(BspFile bsp)
     {
-        if (OriginFilter?.Count == 0)
+        if (OriginFilter is { Count: 0 })
         {
             Logger.Warn("No games selected.");
             return false;

--- a/src/Lumper.Test/PakfileRefactoringTests.cs
+++ b/src/Lumper.Test/PakfileRefactoringTests.cs
@@ -1011,9 +1011,7 @@ public class PakFileLumpRefactoringTests
         BspFile bspFile = TestUtils.CreateMockBspFile();
         PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
 
-        pakfileLump.Entries.Add(
-            new PakfileEntry(pakfileLump, fileName, new MemoryStream(BspFile.Encoding.GetBytes(inData)))
-        );
+        TestUtils.AddPakfileEntry(pakfileLump, fileName, inData);
 
         List<UpdateType> changes = pakfileLump.UpdatePathReferences(
             oldPath,
@@ -1058,15 +1056,9 @@ public class PakFileLumpRefactoringTests
             }
             """;
 
-        pakfileLump.Entries.Add(
-            new PakfileEntry(pakfileLump, "test1.vmt", new MemoryStream(BspFile.Encoding.GetBytes(content1)))
-        );
-        pakfileLump.Entries.Add(
-            new PakfileEntry(pakfileLump, "test2.vmt", new MemoryStream(BspFile.Encoding.GetBytes(content2)))
-        );
-        pakfileLump.Entries.Add(
-            new PakfileEntry(pakfileLump, "test3.vmt", new MemoryStream(BspFile.Encoding.GetBytes(content3)))
-        );
+        TestUtils.AddPakfileEntry(pakfileLump, "test1.vmt", content1);
+        TestUtils.AddPakfileEntry(pakfileLump, "test2.vmt", content2);
+        TestUtils.AddPakfileEntry(pakfileLump, "test3.vmt", content3);
 
         List<UpdateType> changes = pakfileLump.UpdatePathReferences(
             "materials/test/foo.vtf",
@@ -1170,8 +1162,8 @@ public class PakFileLumpRefactoringTests
         texDataLump.Data.Add(texData);
 
         List<UpdateType> changes = pakfileLump.UpdatePathReferences(
-            "materials/test/example.vtf",
-            "materials/test/renamed.vtf",
+            "materials/test/example.vmt",
+            "materials/test/renamed.vmt",
             [UpdateType.TexData]
         );
 
@@ -1518,9 +1510,7 @@ public class PakFileLumpRefactoringTests
         BspFile bspFile = TestUtils.CreateMockBspFile();
         PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
 
-        pakfileLump.Entries.Add(
-            new PakfileEntry(pakfileLump, "materials/maps/surf_utopia/cubemapdefault.vmt", new MemoryStream())
-        );
+        TestUtils.AddPakfileEntry(pakfileLump, "materials/maps/surf_utopia/cubemapdefault.vmt");
         pakfileLump.IsModified = false; // Creating new PakFileEntry from stream sets IsModified to true, so we reset it.
 
         pakfileLump.ProcessMapRename("surf_utopia", "surf_newname");
@@ -1538,9 +1528,7 @@ public class PakFileLumpRefactoringTests
         BspFile bspFile = TestUtils.CreateMockBspFile();
         PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
 
-        pakfileLump.Entries.Add(
-            new PakfileEntry(pakfileLump, "scripts/soundscapes_kz_example.txt", new MemoryStream())
-        );
+        TestUtils.AddPakfileEntry(pakfileLump, "scripts/soundscapes_kz_example.txt");
         pakfileLump.IsModified = false;
 
         pakfileLump.ProcessMapRename("kz_example", "kz_renamed");
@@ -1558,9 +1546,7 @@ public class PakFileLumpRefactoringTests
         BspFile bspFile = TestUtils.CreateMockBspFile();
         PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
 
-        pakfileLump.Entries.Add(
-            new PakfileEntry(pakfileLump, "scripts/soundscapes_bhop_forest.vsc", new MemoryStream())
-        );
+        TestUtils.AddPakfileEntry(pakfileLump, "scripts/soundscapes_bhop_forest.vsc");
         pakfileLump.IsModified = false;
 
         pakfileLump.ProcessMapRename("bhop_forest", "bhop_jungle");
@@ -1578,7 +1564,7 @@ public class PakFileLumpRefactoringTests
         BspFile bspFile = TestUtils.CreateMockBspFile();
         PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
 
-        pakfileLump.Entries.Add(new PakfileEntry(pakfileLump, "maps/surf_mesa_level_sounds.txt", new MemoryStream()));
+        TestUtils.AddPakfileEntry(pakfileLump, "maps/surf_mesa_level_sounds.txt");
         pakfileLump.IsModified = false;
 
         pakfileLump.ProcessMapRename("surf_mesa", "surf_plateau");
@@ -1596,7 +1582,7 @@ public class PakFileLumpRefactoringTests
         BspFile bspFile = TestUtils.CreateMockBspFile();
         PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
 
-        pakfileLump.Entries.Add(new PakfileEntry(pakfileLump, "maps/kz_climb_particles.txt", new MemoryStream()));
+        TestUtils.AddPakfileEntry(pakfileLump, "maps/kz_climb_particles.txt");
         pakfileLump.IsModified = false;
 
         pakfileLump.ProcessMapRename("kz_climb", "kz_ascent");
@@ -1615,11 +1601,11 @@ public class PakFileLumpRefactoringTests
         PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
 
         // Add multiple different types of files
-        pakfileLump.Entries.Add(new PakfileEntry(pakfileLump, "materials/maps/surf_y/texture.vmt", new MemoryStream()));
-        pakfileLump.Entries.Add(new PakfileEntry(pakfileLump, "scripts/soundscapes_surf_y.txt", new MemoryStream()));
-        pakfileLump.Entries.Add(new PakfileEntry(pakfileLump, "maps/surf_y_level_sounds.txt", new MemoryStream()));
-        pakfileLump.Entries.Add(new PakfileEntry(pakfileLump, "maps/surf_y_particles.txt", new MemoryStream()));
-        pakfileLump.Entries.Add(new PakfileEntry(pakfileLump, "materials/models/props/barrel.vmt", new MemoryStream())); // Shouldn't be changed
+        TestUtils.AddPakfileEntry(pakfileLump, "materials/maps/surf_y/texture.vmt");
+        TestUtils.AddPakfileEntry(pakfileLump, "scripts/soundscapes_surf_y.txt");
+        TestUtils.AddPakfileEntry(pakfileLump, "maps/surf_y_level_sounds.txt");
+        TestUtils.AddPakfileEntry(pakfileLump, "maps/surf_y_particles.txt");
+        TestUtils.AddPakfileEntry(pakfileLump, "materials/models/props/barrel.vmt"); // Shouldn't be changed
         pakfileLump.IsModified = false;
 
         pakfileLump.ProcessMapRename("surf_y", "surf_mastery");
@@ -1642,9 +1628,7 @@ public class PakFileLumpRefactoringTests
         PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
 
         // Add pakfile entry with differently cased map name
-        pakfileLump.Entries.Add(
-            new PakfileEntry(pakfileLump, "materials/maps/SURF_UTOPIA/texture.vmt", new MemoryStream())
-        );
+        TestUtils.AddPakfileEntry(pakfileLump, "materials/maps/SURF_UTOPIA/texture.vmt");
         pakfileLump.IsModified = false;
 
         pakfileLump.ProcessMapRename("surf_utopia", "surf_paradise");
@@ -1662,7 +1646,7 @@ public class PakFileLumpRefactoringTests
         BspFile bspFile = TestUtils.CreateMockBspFile();
         PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
 
-        pakfileLump.Entries.Add(new PakfileEntry(pakfileLump, "materials/models/props/barrel.vmt", new MemoryStream()));
+        TestUtils.AddPakfileEntry(pakfileLump, "materials/models/props/barrel.vmt");
         pakfileLump.IsModified = false;
 
         pakfileLump.ProcessMapRename("surf_utopia", "surf_paradise");
@@ -1680,9 +1664,7 @@ public class PakFileLumpRefactoringTests
         BspFile bspFile = TestUtils.CreateMockBspFile();
         PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
 
-        pakfileLump.Entries.Add(
-            new PakfileEntry(pakfileLump, "materials/maps/surf_utopia/subfolder/texture.vmt", new MemoryStream())
-        );
+        TestUtils.AddPakfileEntry(pakfileLump, "materials/maps/surf_utopia/subfolder/texture.vmt");
         pakfileLump.IsModified = false;
 
         pakfileLump.ProcessMapRename("surf_utopia", "surf_paradise");
@@ -1701,9 +1683,7 @@ public class PakFileLumpRefactoringTests
         PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
 
         // Add entry with a name that contains the map name as a substring
-        pakfileLump.Entries.Add(
-            new PakfileEntry(pakfileLump, "materials/maps/surf_utopia2/texture.vmt", new MemoryStream())
-        );
+        TestUtils.AddPakfileEntry(pakfileLump, "materials/maps/surf_utopia2/texture.vmt");
         pakfileLump.IsModified = false;
 
         pakfileLump.ProcessMapRename("surf_utopia", "surf_paradise");
@@ -1721,9 +1701,7 @@ public class PakFileLumpRefactoringTests
         BspFile bspFile = TestUtils.CreateMockBspFile();
         PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
 
-        pakfileLump.Entries.Add(
-            new PakfileEntry(pakfileLump, "materials/maps/surf_different/texture.vmt", new MemoryStream())
-        );
+        TestUtils.AddPakfileEntry(pakfileLump, "materials/maps/surf_different/texture.vmt");
         pakfileLump.IsModified = false;
 
         pakfileLump.ProcessMapRename("surf_utopia", "surf_paradise");
@@ -1742,15 +1720,9 @@ public class PakFileLumpRefactoringTests
         PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
 
         // Add entries with similar but different paths
-        pakfileLump.Entries.Add(
-            new PakfileEntry(pakfileLump, "materials/maps_custom/surf_utopia/texture.vmt", new MemoryStream())
-        );
-        pakfileLump.Entries.Add(
-            new PakfileEntry(pakfileLump, "scripts/soundscape_surf_utopia.txt", new MemoryStream())
-        );
-        pakfileLump.Entries.Add(
-            new PakfileEntry(pakfileLump, "maps/surf_utopia_particles_custom.txt", new MemoryStream())
-        );
+        TestUtils.AddPakfileEntry(pakfileLump, "materials/maps_custom/surf_utopia/texture.vmt");
+        TestUtils.AddPakfileEntry(pakfileLump, "scripts/soundscape_surf_utopia.txt");
+        TestUtils.AddPakfileEntry(pakfileLump, "maps/surf_utopia_particles_custom.txt");
         pakfileLump.IsModified = false;
 
         pakfileLump.ProcessMapRename("surf_utopia", "surf_paradise");

--- a/src/Lumper.Test/PakfileRefactoringTests.cs
+++ b/src/Lumper.Test/PakfileRefactoringTests.cs
@@ -1162,8 +1162,8 @@ public class PakFileLumpRefactoringTests
         texDataLump.Data.Add(texData);
 
         List<UpdateType> changes = pakfileLump.UpdatePathReferences(
-            "materials/test/example.vmt",
-            "materials/test/renamed.vmt",
+            "materials/test/example",
+            "materials/test/renamed",
             [UpdateType.TexData]
         );
 

--- a/src/Lumper.Test/RemoveAssetJobTests.cs
+++ b/src/Lumper.Test/RemoveAssetJobTests.cs
@@ -1,0 +1,282 @@
+﻿namespace Lumper.Test;
+
+using Lumper.Lib.AssetManifest;
+using Lumper.Lib.Bsp;
+using Lumper.Lib.Bsp.Lumps.BspLumps;
+using Lumper.Lib.Jobs;
+
+[TestFixture]
+public class RemoveAssetJobTests
+{
+    private BspFile _bspFile;
+    private PakfileLump _pakfileLump;
+    private Dictionary<string, List<AssetManifest.Asset>> _manifest = null!;
+    private static readonly List<string> Origins = ["hl2", "css", "portal2", "csgo"];
+
+    [SetUp]
+    public void Setup()
+    {
+        // Create mock BSP file
+        _bspFile = TestUtils.CreateMockBspFile();
+        _pakfileLump = _bspFile.GetLump<PakfileLump>();
+
+        // Clear any existing entries
+        _pakfileLump.Entries.Clear();
+
+        // Setup manifest for testing
+        _manifest = TestUtils.GetMutableAssetManifest();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _bspFile.Dispose();
+    }
+
+    [Test]
+    public void Run_HashMatchingEntry_IsRemoved()
+    {
+        _manifest["hash1"] = [new AssetManifest.Asset { Origin = "hl2", Path = "materials/hl2/texture.vtf" }];
+        TestUtils.AddPakfileEntryWithHash(_pakfileLump, "hash1", "materials/hl2/texture.vtf");
+
+        var job = new RemoveAssetJob { OriginFilter = Origins };
+        bool result = job.Run(_bspFile);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(_pakfileLump.Entries, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void Run_HashMatchingEntry_UpdatesPathReferences()
+    {
+        _manifest["hash1"] = [new AssetManifest.Asset { Origin = "hl2", Path = "materials/hl2/texture.vtf" }];
+        TestUtils.AddPakfileEntryWithHash(_pakfileLump, "hash1", "materials/my_map/some_idiot_renamed_a_hl2_file.vtf");
+        TestUtils.AddPakfileEntry(
+            _pakfileLump,
+            "materials/whatever.vmt",
+            """Material" { "$basetexture" "my_map/some_idiot_renamed_a_hl2_file" }"""
+        );
+
+        var job = new RemoveAssetJob { OriginFilter = Origins };
+        bool result = job.Run(_bspFile);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(_pakfileLump.Entries, Has.Count.EqualTo(1));
+            Assert.That(
+                BspFile.Encoding.GetString(_pakfileLump.Entries[0].GetData()),
+                Is.EqualTo("""Material" { "$basetexture" "hl2/texture" }""")
+            );
+        });
+    }
+
+    [Test]
+    public void Run_MultipleOriginsWithPriority_PicksHighestPriority()
+    {
+        // Add two assets with the same hash but different origins
+        _manifest["hash1"] =
+        [
+            new AssetManifest.Asset { Origin = "csgo", Path = "materials/csgo/texture.vtf" },
+            new AssetManifest.Asset { Origin = "hl2", Path = "materials/hl2/texture.vtf" },
+        ];
+
+        // Add a pakfile entry with that hash but using a custom path
+        TestUtils.AddPakfileEntryWithHash(_pakfileLump, "hash1", "materials/my_map/custom_texture.vtf");
+        TestUtils.AddPakfileEntry(
+            _pakfileLump,
+            "materials/custom.vmt",
+            """Material" { "$basetexture" "my_map/custom_texture" }"""
+        );
+
+        var job = new RemoveAssetJob { OriginFilter = Origins };
+        bool result = job.Run(_bspFile);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(_pakfileLump.Entries, Has.Count.EqualTo(1));
+            // Should update to hl2 path as it has higher priority than csgo
+            Assert.That(
+                BspFile.Encoding.GetString(_pakfileLump.Entries[0].GetData()),
+                Is.EqualTo("""Material" { "$basetexture" "hl2/texture" }""")
+            );
+        });
+    }
+
+    [Test]
+    public void Run_MultipleOriginsNoneInPriority_UsesFirstAsset()
+    {
+        // Add two assets with the same hash but from origins not in priority list
+        _manifest["hash1"] =
+        [
+            new AssetManifest.Asset { Origin = "gmod", Path = "materials/gmod/texture.vtf" },
+            new AssetManifest.Asset { Origin = "l4d2", Path = "materials/l4d2/texture.vtf" },
+        ];
+
+        TestUtils.AddPakfileEntryWithHash(_pakfileLump, "hash1", "materials/my_map/custom_texture.vtf");
+        TestUtils.AddPakfileEntry(
+            _pakfileLump,
+            "materials/custom.vmt",
+            """Material" { "$basetexture" "my_map/custom_texture" }"""
+        );
+
+        var job = new RemoveAssetJob { OriginFilter = ["gmod", "l4d2"] };
+        bool result = job.Run(_bspFile);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(_pakfileLump.Entries, Has.Count.EqualTo(1));
+            // Should use the first asset (gmod) since none are in priority list
+            Assert.That(
+                BspFile.Encoding.GetString(_pakfileLump.Entries[0].GetData()),
+                Is.EqualTo("""Material" { "$basetexture" "gmod/texture" }""")
+            );
+        });
+    }
+
+    [Test]
+    public void Run_PriorityMatchIsNotInOriginFilter_StillRemovesAsset()
+    {
+        // Add assets with the same hash, one in priority list but not in filter
+        _manifest["hash1"] =
+        [
+            new AssetManifest.Asset { Origin = "hl2", Path = "materials/hl2/texture.vtf" },
+            new AssetManifest.Asset { Origin = "gmod", Path = "materials/gmod/texture.vtf" },
+        ];
+
+        TestUtils.AddPakfileEntryWithHash(_pakfileLump, "hash1", "materials/my_map/custom_texture.vtf");
+
+        // Only filter for gmod
+        var job = new RemoveAssetJob { OriginFilter = ["gmod"] };
+        bool result = job.Run(_bspFile);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(_pakfileLump.Entries, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void Run_MultipleMatchingOriginsWithPathMatch_UsesExactMatch()
+    {
+        // Add multiple assets with same hash, including one with exact path match
+        _manifest["hash1"] =
+        [
+            new AssetManifest.Asset { Origin = "csgo", Path = "materials/csgo/texture.vtf" },
+            new AssetManifest.Asset { Origin = "css", Path = "materials/css/texture.vtf" },
+        ];
+
+        // The entry has exact path match with css origin
+        TestUtils.AddPakfileEntryWithHash(_pakfileLump, "hash1", "materials/css/texture.vtf");
+        TestUtils.AddPakfileEntry(
+            _pakfileLump,
+            "materials/custom.vmt",
+            """Material" { "$basetexture" "css/texture" }"""
+        );
+
+        var job = new RemoveAssetJob { OriginFilter = Origins };
+        bool result = job.Run(_bspFile);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(_pakfileLump.Entries, Has.Count.EqualTo(1));
+            // No actual change should happen since the paths match
+            Assert.That(
+                BspFile.Encoding.GetString(_pakfileLump.Entries[0].GetData()),
+                Is.EqualTo("""Material" { "$basetexture" "css/texture" }""")
+            );
+        });
+    }
+
+    [Test]
+    public void Run_NoMatchingHash_ReturnsFalse()
+    {
+        // Add an entry with a hash that doesn't exist in the manifest
+        TestUtils.AddPakfileEntryWithHash(_pakfileLump, "nonexistentHash", "materials/custom/texture.vtf");
+
+        var job = new RemoveAssetJob { OriginFilter = Origins };
+        bool result = job.Run(_bspFile);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.False);
+            Assert.That(_pakfileLump.Entries, Has.Count.EqualTo(1), "Entry should not be removed");
+        });
+    }
+
+    [Test]
+    public void Run_EmptyPakfileLump_ReturnsFalse()
+    {
+        // PakfileLump is already empty from Setup()
+        var job = new RemoveAssetJob { OriginFilter = Origins };
+        bool result = job.Run(_bspFile);
+
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Run_MultipleEntriesRemoved_ReturnsTrue()
+    {
+        // Add multiple entries that match assets in the manifest
+        _manifest["hash1"] = [new AssetManifest.Asset { Origin = "hl2", Path = "materials/hl2/texture1.vtf" }];
+        _manifest["hash2"] = [new AssetManifest.Asset { Origin = "css", Path = "materials/css/texture2.vtf" }];
+
+        TestUtils.AddPakfileEntryWithHash(_pakfileLump, "hash1", "materials/hl2/texture1.vtf");
+        TestUtils.AddPakfileEntryWithHash(_pakfileLump, "hash2", "materials/css/texture2.vtf");
+
+        var job = new RemoveAssetJob { OriginFilter = Origins };
+        bool result = job.Run(_bspFile);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(_pakfileLump.Entries, Is.Empty, "All entries should be removed");
+        });
+    }
+
+    [Test]
+    public void Run_HashMatchesButOriginNotInFilter_ReturnsFalse()
+    {
+        // Add an asset with origin not in the filter
+        _manifest["hash1"] = [new AssetManifest.Asset { Origin = "portal", Path = "materials/portal/texture.vtf" }];
+        TestUtils.AddPakfileEntryWithHash(_pakfileLump, "hash1", "materials/portal/texture.vtf");
+
+        // Filter only includes hl2, css, etc, but not portal
+        var job = new RemoveAssetJob { OriginFilter = Origins };
+        bool result = job.Run(_bspFile);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.False);
+            Assert.That(_pakfileLump.Entries, Has.Count.EqualTo(1), "Entry should not be removed");
+        });
+    }
+
+    [Test]
+    public void Run_NullOriginFilter_RemovesAllMatchingAssets()
+    {
+        // Add assets from various origins
+        _manifest["hash1"] = [new AssetManifest.Asset { Origin = "hl2", Path = "materials/hl2/texture.vtf" }];
+        _manifest["hash2"] = [new AssetManifest.Asset { Origin = "portal", Path = "materials/portal/texture.vtf" }];
+
+        TestUtils.AddPakfileEntryWithHash(_pakfileLump, "hash1", "materials/hl2/texture.vtf");
+        TestUtils.AddPakfileEntryWithHash(_pakfileLump, "hash2", "materials/portal/texture.vtf");
+
+        // Null filter should remove all matching assets regardless of origin
+        var job = new RemoveAssetJob { OriginFilter = null };
+        bool result = job.Run(_bspFile);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True);
+            Assert.That(_pakfileLump.Entries, Is.Empty, "All entries should be removed with null filter");
+        });
+    }
+}


### PR DESCRIPTION
Did the stuff in RemoveAssetJob slightly wrong and decided was complex enough for unit tests, these are a mixture of myself and LLM-generated.

Tried mocking stuff more so I didn't need to test path refactoring in this file but BspFile and related classes are so hard to mock. Don't think reflection-based stuff hidden away in TestUtils is too bad.