### PR TITLE
Required game detection

### DIFF
--- a/src/Lumper.CLI/CommandLineOptions.cs
+++ b/src/Lumper.CLI/CommandLineOptions.cs
@@ -99,7 +99,7 @@ public class CommandLineOptions
 
     [Option(
         'a',
-        "check-assets",
+        "checkAssets",
         Default = false,
         Required = false,
         HelpText = "[VALIDATOR] Check whether the paklump contains official Valve assets, exits with 1 if so."
@@ -121,4 +121,13 @@ public class CommandLineOptions
         HelpText = "[VALIDATOR] Check the BSP file against a set of entity rules at a given path."
     )]
     public string? CustomEntityRules { get; set; }
+
+    [Option(
+        'g',
+        "requiredGames",
+        Default = false,
+        Required = false,
+        HelpText = "Prints list of required games for the BSP file. Not technically a validator."
+    )]
+    public bool RequiredGames { get; set; }
 }

--- a/src/Lumper.CLI/Program.cs
+++ b/src/Lumper.CLI/Program.cs
@@ -10,6 +10,7 @@ using Lumper.Lib.Bsp.Lumps.BspLumps;
 using Lumper.Lib.Bsp.Struct;
 using Lumper.Lib.EntityRules;
 using Lumper.Lib.Jobs;
+using Lumper.Lib.RequiredGames;
 using NLog;
 using NLog.Config;
 using NLog.Targets;
@@ -77,6 +78,9 @@ internal sealed class Program
         // If this is ever true, the application is being used to perform validations, then exit with 0 or 1.
         bool inValidationMode = false;
         bool validationSuccess = true;
+
+        if (options.RequiredGames)
+            PrintRequiredGames(bspFile);
 
         if (options.CheckAssets)
         {
@@ -173,6 +177,12 @@ internal sealed class Program
             stopwatch.Stop();
             Logger.Info($"Job completed in {stopwatch.ElapsedMilliseconds}ms");
         }
+    }
+
+    private static void PrintRequiredGames(BspFile bspFile)
+    {
+        (List<RequiredGames.PackedAsset> _, string summary) = RequiredGames.GetRequiredGames(bspFile);
+        Logger.Info(summary.Length > 0 ? $"Required games: {summary}" : "No required games found in BSP file");
     }
 
     private static bool CheckAssets(BspFile bspFile)

--- a/src/Lumper.Lib/AssetManifest/AssetManifest.cs
+++ b/src/Lumper.Lib/AssetManifest/AssetManifest.cs
@@ -42,6 +42,15 @@ public static class AssetManifest
     public static HashSet<string> Origins { get; } = [];
 
     /// <summary>
+    /// Origins we prioritise when renaming assets that match a hash but not the original filename,
+    /// or there's multiple officials with the same hash, where one path matches but a more
+    /// accessible game has the same asset with a different path.
+    /// In both case, we update references to the most accessible path everywhere to avoid missing
+    /// textures as best we can. This is biased towards Momentum!
+    /// </summary>
+    public static readonly List<string> RenamedOriginPriority = ["hl2", "tf2", "css", "csgo"];
+
+    /// <summary>
     /// Preload the asset manifest. UI wants this, CLI doesn't. Don't call from the UI thread!
     /// </summary>
     public static void Preload()

--- a/src/Lumper.Lib/Jobs/RemoveAssetJob.cs
+++ b/src/Lumper.Lib/Jobs/RemoveAssetJob.cs
@@ -22,15 +22,6 @@ public class RemoveAssetJob : Job, IJob
 
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-    /// <summary>
-    /// Origins we prioritise when renaming assets that match a hash but not the original filename,
-    /// or there's multiple officials with the same hash, where one path matches but a more
-    /// accessible game has the same asset with a different path.
-    /// In both case, we update references to the most accessible path everywhere to avoid missing
-    /// textures as best we can. This is biased towards Momentum!
-    /// </summary>
-    private static readonly string[] RenamedOriginPriority = ["hl2", "tf2", "css", "csgo"];
-
     public override bool Run(BspFile bsp)
     {
         if (OriginFilter is { Count: 0 })
@@ -67,7 +58,7 @@ public class RemoveAssetJob : Job, IJob
             AssetManifest.Asset? bestAsset = null;
             if (assets.Count > 1)
             {
-                foreach (string origin in RenamedOriginPriority)
+                foreach (string origin in AssetManifest.RenamedOriginPriority)
                 {
                     bestAsset = assets.FirstOrDefault(asset => asset.Origin == origin);
                     if (bestAsset != null)

--- a/src/Lumper.Lib/RequiredGames/RequiredGames.cs
+++ b/src/Lumper.Lib/RequiredGames/RequiredGames.cs
@@ -1,0 +1,171 @@
+﻿namespace Lumper.Lib.RequiredGames;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Lumper.Lib.AssetManifest;
+using Lumper.Lib.Bsp;
+using Lumper.Lib.Bsp.Lumps.BspLumps;
+using Lumper.Lib.Bsp.Lumps.GameLumps;
+using Lumper.Lib.Bsp.Struct;
+
+public static class RequiredGames
+{
+    public class PackedAsset
+    {
+        public required string Type { get; init; }
+
+        public required string Path { get; init; }
+
+        private readonly List<string> _games = [];
+        public required List<string> Games
+        {
+            get => _games;
+            init
+            {
+                List<string> priorityGames = AssetManifest.RenamedOriginPriority;
+                _games = value
+                    .OrderBy(game =>
+                    {
+                        // First sort: ascending by index in priorityGames, if not found, otherwise use priorityGames.Count
+                        // to stick everything else at the end.
+                        int priority = priorityGames.IndexOf(game);
+                        if (priority != -1)
+                            return priority;
+
+                        return priorityGames.Count;
+                    })
+                    .ThenByDescending(game =>
+                    {
+                        // Second sort: descending by how many times the game occurs.
+                        int priority = priorityGames.IndexOf(game);
+                        if (priority == -1)
+                            return 0;
+
+                        return priorityGames.Count + value.Count(asset => asset.Contains(asset));
+                    })
+                    .ToList();
+            }
+        }
+
+        public string GamesString => string.Join(", ", Games);
+    }
+
+    public static (List<PackedAsset> assets, string summary) GetRequiredGames(BspFile? bspFile)
+    {
+        if (bspFile == null)
+            return ([], "N/A");
+
+        var matches = new List<PackedAsset>();
+        matches.AddRange(GetMatchingTexData(bspFile));
+        matches.AddRange(GetMatchingModelData(bspFile));
+
+        // Unique Games should be collection of games that *have* to be installed, i.e.
+        // no other collection of games exists that for every RequiredGame in Results,
+        // at least one game in the collection is in that RequiredGame
+        var minimumSet = new HashSet<string>();
+        var uniqueGames = matches.SelectMany(r => r.Games).Distinct().ToHashSet();
+
+        // Prioritize HL2 above all else
+        if (uniqueGames.Contains("hl2"))
+            minimumSet.Add("hl2");
+
+        // For all uniqueGames, if there's a game for which at least one asset includes *only* that game,
+        // add that game to the minimum set.
+        foreach (string game in uniqueGames)
+        {
+            if (matches.Any(asset => asset.Games.Count == 1 && asset.Games.Contains(game)))
+                minimumSet.Add(game);
+        }
+
+        // For all remaining uniqueGames, sort them by how many times they appear in the matches
+        var ordered = uniqueGames
+            .OrderByDescending(game => matches.Count(asset => asset.Games.Contains(game)))
+            .ThenBy(game => game) // Sort alphabetically as a tiebreaker
+            .ToList();
+
+        // For each game in the ordered list, if it appears in any of the matches, add it, unless for every match,
+        // at least one game in the minimum set is already included.
+        foreach (string game in ordered)
+        {
+            if (
+                matches.Any(asset =>
+                    asset.Games.Contains(game) && !minimumSet.Any(minGame => asset.Games.Contains(minGame))
+                )
+            )
+                minimumSet.Add(game);
+        }
+
+        string str = minimumSet.Count == 0 ? "N/A" : string.Join(", ", minimumSet);
+
+        return (matches, str);
+    }
+
+    private static List<PackedAsset> GetMatchingTexData(BspFile bspFile)
+    {
+        List<PackedAsset> matches = [];
+
+        TexDataLump texDataLump =
+            bspFile.GetLump<TexDataLump>() ?? throw new InvalidDataException("TexData lump not found");
+
+        // This probably hasn't loaded yet, make sure we do in TP thread.
+        Dictionary<string, List<string>> pathManifest = AssetManifest.PathManifest;
+
+        foreach (TexData texData in texDataLump.Data)
+        {
+            pathManifest.TryGetValue(
+                $"materials/{texData.TexName.ToLowerInvariant()}.vmt",
+                out List<string>? matchingOrigins
+            );
+
+            if (matchingOrigins == null)
+                continue;
+
+            matches.Add(
+                new PackedAsset
+                {
+                    Type = "Texture",
+                    Path = texData.TexName,
+                    Games = matchingOrigins,
+                }
+            );
+        }
+
+        return matches;
+    }
+
+    private static List<PackedAsset> GetMatchingModelData(BspFile bspFile)
+    {
+        List<PackedAsset> matches = [];
+
+        List<string>? props = bspFile.GetLump<GameLump>().GetLump<Sprp>()?.StaticPropsDict?.Data;
+
+        if (props == null)
+            return [];
+
+        Dictionary<string, List<string>> pathManifest = AssetManifest.PathManifest;
+
+        foreach (string prop in props)
+        {
+            pathManifest.TryGetValue(prop, out List<string>? matchingOrigins);
+
+            if (matchingOrigins == null)
+                continue;
+
+            matches.Add(
+                new PackedAsset
+                {
+                    Type = "Static Prop",
+                    Path = prop,
+                    Games = matchingOrigins,
+                }
+            );
+        }
+
+        return matches;
+    }
+
+    // TODO: Don't have support for searching pakfile entries or entities. Probably possible to expose static methods
+    // from PakfileLump.Refactoring but it's complex and only works for a small proportion of cases.
+}

--- a/src/Lumper.UI/Services/PageService.cs
+++ b/src/Lumper.UI/Services/PageService.cs
@@ -9,6 +9,7 @@ using Lumper.UI.ViewModels.Pages.EntityReview;
 using Lumper.UI.ViewModels.Pages.Jobs;
 using Lumper.UI.ViewModels.Pages.PakfileExplorer;
 using Lumper.UI.ViewModels.Pages.RawEntities;
+using Lumper.UI.ViewModels.Pages.RequiredGames;
 using Lumper.UI.ViewModels.Pages.VtfBrowser;
 using NLog;
 using ReactiveUI;
@@ -24,6 +25,7 @@ public enum Page
     Jobs,
     RawEntities,
     EntityReview,
+    RequiredGames,
 }
 
 /// <summary>
@@ -49,6 +51,7 @@ public sealed class PageService : ReactiveObject
             { Page.Jobs, new LazyPage<JobsViewModel>(false) },
             { Page.RawEntities, new LazyPage<RawEntitiesViewModel>(true) },
             { Page.EntityReview, new LazyPage<EntityReviewViewModel>(true) },
+            { Page.RequiredGames, new LazyPage<RequiredGamesViewModel>(true) },
         };
 
     [Reactive]

--- a/src/Lumper.UI/ViewModels/Pages/RequiredGames/RequiredGamesViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/RequiredGames/RequiredGamesViewModel.cs
@@ -1,0 +1,50 @@
+namespace Lumper.UI.ViewModels.Pages.RequiredGames;
+
+using System;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Lumper.Lib.RequiredGames;
+using Lumper.UI.Services;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+using Views.Pages.RequiredGames;
+
+public sealed class RequiredGamesViewModel : ViewModelWithView<RequiredGamesViewModel, RequiredGamesView>, IDisposable
+{
+    [Reactive]
+    public List<RequiredGames.PackedAsset> Results { get; set; } = [];
+
+    [Reactive]
+    public string Required { get; set; } = "";
+
+    private readonly Subject<Unit> _recomputer = new();
+
+    public RequiredGamesViewModel()
+    {
+        BspService
+            .Instance.WhenAnyValue(x => x.BspFile)
+            .ObserveOn(RxApp.TaskpoolScheduler)
+            .CombineLatest(_recomputer)
+            .Select(tup => RequiredGames.GetRequiredGames(tup.First))
+            .ObserveOn(RxApp.MainThreadScheduler)
+            .Subscribe(t =>
+            {
+                Results = t.assets;
+                Required = t.summary;
+            });
+
+        Recompute();
+    }
+
+    private void Recompute()
+    {
+        _recomputer.OnNext(Unit.Default);
+    }
+
+    public void Dispose()
+    {
+        _recomputer.Dispose();
+    }
+}

--- a/src/Lumper.UI/Views/BspInfo/BspInfoView.axaml
+++ b/src/Lumper.UI/Views/BspInfo/BspInfoView.axaml
@@ -57,6 +57,10 @@
         <Run Classes="R" Name="Compression" />
         <LineBreak />
 
+        <Run Classes="L" Text="Required Games  " />
+        <Run Classes="R" Name="RequiredGamesStr" />
+        <LineBreak />
+
         <Run Classes="L" Text="Entities        " />
         <Run Classes="R" Name="Entities" />
         <Run Classes="R" Name="BadEntities" Foreground="IndianRed" />

--- a/src/Lumper.UI/Views/BspInfo/BspInfoView.axaml.cs
+++ b/src/Lumper.UI/Views/BspInfo/BspInfoView.axaml.cs
@@ -9,6 +9,7 @@ using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.ReactiveUI;
+using Lib.RequiredGames;
 using Lumper.Lib.EntityRules;
 using Lumper.UI.Services;
 using Lumper.UI.ViewModels.BspInfo;
@@ -27,6 +28,7 @@ public partial class BspInfoView : ReactiveWindow<BspInfoViewModel>
             InitCompression();
             InitEntities(disposables);
             InitPakfile(disposables);
+            InitRequiredGames(disposables);
         });
     }
 
@@ -47,6 +49,19 @@ public partial class BspInfoView : ReactiveWindow<BspInfoViewModel>
             Compression.Foreground = Brushes.GreenYellow;
             Compression.Text = "Compressed";
         }
+    }
+
+    private void InitRequiredGames(CompositeDisposable disposables)
+    {
+        RequiredGamesStr.Text = "Checking required games...";
+
+        BspService
+            .Instance.WhenAnyValue(x => x.BspFile)
+            .ObserveOn(RxApp.TaskpoolScheduler)
+            .Select(bsp => bsp != null ? RequiredGames.GetRequiredGames(bsp).summary : "")
+            .ObserveOn(RxApp.MainThreadScheduler)
+            .Subscribe(requiredGames => RequiredGamesStr.Text = requiredGames)
+            .DisposeWith(disposables);
     }
 
     private void InitEntities(CompositeDisposable disposables)

--- a/src/Lumper.UI/Views/MainWindow.axaml
+++ b/src/Lumper.UI/Views/MainWindow.axaml
@@ -120,6 +120,8 @@
                         CommandParameter="{x:Static service:Page.VtfBrowser}" InputGesture="Ctrl+D5" />
               <MenuItem Header="_Jobs" Command="{Binding PageService.ViewPage}"
                         CommandParameter="{x:Static service:Page.Jobs}" InputGesture="Ctrl+D6" />
+              <MenuItem Header="Required Games" Command="{Binding PageService.ViewPage}"
+                        CommandParameter="{x:Static service:Page.RequiredGames}" InputGesture="Ctrl+D7" />
             </MenuItem>
             <MenuItem Header="_Tools">
               <MenuItem Header="_Map Summary" Command="{Binding BspInfoCommand}"
@@ -148,7 +150,7 @@
               <Setter Property="BorderBrush" Value="#22FFFFFF" />
               <Style Selector="^ StackPanel">
                 <Setter Property="Orientation" Value="Horizontal" />
-                <Setter Property="Spacing" Value="4" />
+                <Setter Property="Spacing" Value="6" />
                 <Style Selector="^ TextBlock">
                   <Setter Property="VerticalAlignment" Value="Center" />
                 </Style>
@@ -197,6 +199,13 @@
               <StackPanel>
                 <materialIcons:MaterialIcon Kind="FormatListChecks" />
                 <TextBlock>Jobs</TextBlock>
+              </StackPanel>
+            </ToggleButton>
+            <ToggleButton Command="{Binding PageService.ViewPage}" Click="PageButton_OnClick"
+                          CommandParameter="{x:Static service:Page.RequiredGames}" HotKey="Ctrl+D7">
+              <StackPanel>
+                <materialIcons:MaterialIcon Kind="HorsebackRiding" />
+                <TextBlock>Required Games</TextBlock>
               </StackPanel>
             </ToggleButton>
           </StackPanel>

--- a/src/Lumper.UI/Views/Pages/RequiredGames/RequiredGamesView.axaml
+++ b/src/Lumper.UI/Views/Pages/RequiredGames/RequiredGamesView.axaml
@@ -1,0 +1,36 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:Lumper.UI.ViewModels.Pages.RequiredGames"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Lumper.UI.Views.Pages.RequiredGames.RequiredGamesView"
+             x:DataType="vm:RequiredGamesViewModel">
+
+  <Grid RowDefinitions="Auto, *">
+    <StackPanel Orientation="Horizontal" Margin="16 12 12 12">
+      <TextBlock FontFamily="{StaticResource Monospace}" Foreground="LightGray" Margin="0 0 8 0" FontWeight="Bold">
+        Required Games:
+      </TextBlock>
+      <TextBlock FontFamily="{StaticResource Monospace}" Text="{Binding Required}"/>
+    </StackPanel>
+    <DataGrid Grid.Row="1" ItemsSource="{Binding Results}" IsReadOnly="True" BorderBrush="#333"
+              BorderThickness="0 1 0 0" VerticalScrollBarVisibility="Visible">
+      <DataGrid.Styles>
+        <Style Selector="ScrollBar">
+          <Setter Property="AllowAutoHide" Value="False" />
+          <Setter Property="Width" Value="16" />
+        </Style>
+      </DataGrid.Styles>
+      <DataGrid.Columns>
+        <DataGridTextColumn Width="Auto" Header="Type" Binding="{Binding Type}"
+                            FontFamily="{StaticResource Monospace}" FontSize="14" />
+        <DataGridTextColumn Width="Auto" Header="Games" Binding="{Binding GamesString}"
+                            FontFamily="{StaticResource Monospace}" FontSize="14" />
+        <DataGridTextColumn Width="Auto" Header="Path" Binding="{Binding Path}"
+                            FontFamily="{StaticResource Monospace}" FontSize="14" />
+      </DataGrid.Columns>
+    </DataGrid>
+  </Grid>
+
+</UserControl>

--- a/src/Lumper.UI/Views/Pages/RequiredGames/RequiredGamesView.axaml.cs
+++ b/src/Lumper.UI/Views/Pages/RequiredGames/RequiredGamesView.axaml.cs
@@ -1,0 +1,12 @@
+namespace Lumper.UI.Views.Pages.RequiredGames;
+
+using Avalonia.ReactiveUI;
+using Lumper.UI.ViewModels.Pages.RequiredGames;
+
+public partial class RequiredGamesView : ReactiveUserControl<RequiredGamesViewModel>
+{
+    public RequiredGamesView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
Adds a page listing the games a BSP requires. Currently it just uses the texdata and static prop lumps, won't detect if someone renames VTF but keeps the VMT the same. Uncommon, and too much work to do right now (issue here https://github.com/momentum-mod/lumper/issues/170)!

![image](https://github.com/user-attachments/assets/bd143557-d6c5-4e63-ba9e-cc70802d199b)

Closes https://github.com/momentum-mod/lumper/issues/142