### PR TITLE
Fix exceptions on BSPs with missing lumps

### DIFF
--- a/src/Lumper.CLI/Program.cs
+++ b/src/Lumper.CLI/Program.cs
@@ -188,7 +188,12 @@ internal sealed class Program
     private static bool CheckAssets(BspFile bspFile)
     {
         // Not bother with OriginFilter stuff, seems very unlikely to be helpful in Momentum's case.
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
+        PakfileLump? pakfileLump = bspFile.GetLump<PakfileLump>();
+        if (pakfileLump == null)
+        {
+            Logger.Warn("BSP does not contain a pakfile lump, skipping asset check.");
+            return true;
+        }
 
         int numMatches = 0;
 
@@ -237,7 +242,10 @@ internal sealed class Program
             throw new InvalidDataException($"Could not load rules file {rulesPath}", ex);
         }
 
-        EntityLump entLump = bspFile.GetLump<EntityLump>();
+        EntityLump? entLump = bspFile.GetLump<EntityLump>();
+
+        if (entLump == null)
+            return false;
 
         int noClassname = 0;
         Dictionary<EntityRule.AllowLevel, HashSet<string>> counts = new()

--- a/src/Lumper.Lib/BSP/BspFile.cs
+++ b/src/Lumper.Lib/BSP/BspFile.cs
@@ -174,8 +174,7 @@ public sealed partial class BspFile : IDisposable
                     );
                 }
 
-                PakfileLump pakfile = GetLump<PakfileLump>();
-                pakfile.ProcessMapRename(Name, newFileName);
+                GetLump<PakfileLump>()?.ProcessMapRename(Name, newFileName);
             }
         }
 
@@ -412,10 +411,10 @@ public sealed partial class BspFile : IDisposable
         }
     }
 
-    public T GetLump<T>()
+    public T? GetLump<T>()
         where T : Lump<BspLumpType>
     {
-        return Lumps.Values.OfType<T>().First();
+        return Lumps.Values.OfType<T>().FirstOrDefault();
     }
 
     public Lump<BspLumpType> GetLump(BspLumpType lumpType)

--- a/src/Lumper.Lib/BSP/IO/BspFileReader.cs
+++ b/src/Lumper.Lib/BSP/IO/BspFileReader.cs
@@ -123,7 +123,7 @@ public sealed class BspFileReader(BspFile file, Stream input, IoHandler? handler
     {
         Lump? gameLump = null;
         LumpHeaderInfo? gameLumpHeader = null;
-        foreach ((Lump? lump, LumpHeaderInfo? header) in Lumps.OrderBy(x => x.Item2.Offset))
+        foreach ((Lump lump, LumpHeaderInfo header) in Lumps.OrderBy(x => x.Item2.Offset))
         {
             if (lump is GameLump)
             {
@@ -149,9 +149,9 @@ public sealed class BspFileReader(BspFile file, Stream input, IoHandler? handler
     private void SortLumps()
     {
         Dictionary<BspLumpType, Lump<BspLumpType>> newLumps = [];
-        foreach ((Lump? lump, _) in Lumps.OrderBy(x => x.Item2.Offset))
+        foreach ((Lump lump, _) in Lumps.OrderBy(x => x.Item2.Offset))
         {
-            (BspLumpType key, Lump<BspLumpType>? value) = _bsp.Lumps.First(x => x.Value == lump);
+            (BspLumpType key, Lump<BspLumpType> value) = _bsp.Lumps.First(x => x.Value == lump);
             newLumps.Add(key, value);
             _bsp.Lumps.Remove(key);
         }
@@ -170,7 +170,7 @@ public sealed class BspFileReader(BspFile file, Stream input, IoHandler? handler
         LumpHeaderInfo? prevHeader = null;
 
         bool first = true;
-        foreach ((Lump? tmpLump, LumpHeaderInfo? header) in Lumps.OrderBy(x => x.Item2.Offset))
+        foreach ((Lump tmpLump, LumpHeaderInfo header) in Lumps.OrderBy(x => x.Item2.Offset))
         {
             var lump = (Lump<BspLumpType>)tmpLump;
             if (first)

--- a/src/Lumper.Lib/BSP/IO/BspFileReader.cs
+++ b/src/Lumper.Lib/BSP/IO/BspFileReader.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Lumper.Lib.Bsp.Enum;
 using Lumper.Lib.Bsp.Lumps;
 using Lumper.Lib.Bsp.Lumps.BspLumps;
+using Lumper.Lib.Bsp.Struct;
 using Newtonsoft.Json;
 using NLog;
 
@@ -211,12 +212,16 @@ public sealed class BspFileReader(BspFile file, Stream input, IoHandler? handler
 
     private void ResolveTexNames()
     {
-        TexDataLump texDataLump = _bsp.GetLump<TexDataLump>();
-        foreach (Struct.TexData texture in texDataLump.Data)
+        TexDataLump? texDataLump = _bsp.GetLump<TexDataLump>();
+        TexDataStringTableLump? texDataStringTableLump = _bsp.GetLump<TexDataStringTableLump>();
+        TexDataStringDataLump? texDataStringDataLump = _bsp.GetLump<TexDataStringDataLump>();
+
+        if (texDataLump == null || texDataStringTableLump == null || texDataStringDataLump == null)
+            return;
+
+        foreach (TexData texture in texDataLump.Data)
         {
-            TexDataStringTableLump texDataStringTableLump = _bsp.GetLump<TexDataStringTableLump>();
             int stringTableOffset = texDataStringTableLump.Data[texture.StringTablePointer];
-            TexDataStringDataLump texDataStringDataLump = _bsp.GetLump<TexDataStringDataLump>();
 
             int end = Array.FindIndex(texDataStringDataLump.Data, stringTableOffset, x => x == 0);
             if (end < 0)
@@ -234,10 +239,14 @@ public sealed class BspFileReader(BspFile file, Stream input, IoHandler? handler
 
     private void ResolveTexData()
     {
-        TexInfoLump texInfoLump = _bsp.GetLump<TexInfoLump>();
-        foreach (Struct.TexInfo texInfo in texInfoLump.Data)
+        TexInfoLump? texInfoLump = _bsp.GetLump<TexInfoLump>();
+        TexDataLump? texDataLump = _bsp.GetLump<TexDataLump>();
+
+        if (texInfoLump == null || texDataLump == null)
+            return;
+
+        foreach (TexInfo texInfo in texInfoLump.Data)
         {
-            TexDataLump texDataLump = _bsp.GetLump<TexDataLump>();
             if (texInfo.TexDataPointer >= 0)
                 texInfo.TexData = texDataLump.Data[texInfo.TexDataPointer];
         }

--- a/src/Lumper.Lib/BSP/IO/BspFileWriter.cs
+++ b/src/Lumper.Lib/BSP/IO/BspFileWriter.cs
@@ -101,15 +101,19 @@ public sealed class BspFileWriter(BspFile file, Stream output, IoHandler? handle
 
     private void ConstructTexDataLumps()
     {
-        List<TexData> texData = _bsp.GetLump<TexDataLump>().Data;
-        TexDataStringDataLump texDataStringDataLump = _bsp.GetLump<TexDataStringDataLump>();
+        TexDataLump? texDataLump = _bsp.GetLump<TexDataLump>();
+        TexDataStringTableLump? texDataStringTableLump = _bsp.GetLump<TexDataStringTableLump>();
+        TexDataStringDataLump? texDataStringDataLump = _bsp.GetLump<TexDataStringDataLump>();
+
+        if (texDataLump == null || texDataStringDataLump == null || texDataStringTableLump == null)
+            return;
 
         // Ensure stringdata lump can fit everything we're about to stuff in
-        texDataStringDataLump.Resize(texData.Sum(x => BspFile.Encoding.GetByteCount(x.TexName) + 1));
+        texDataStringDataLump.Resize(texDataLump.Data.Sum(x => BspFile.Encoding.GetByteCount(x.TexName) + 1));
 
         List<int> stringTable = [];
         int pos = 0;
-        foreach (TexData tex in texData)
+        foreach (TexData tex in texDataLump.Data)
         {
             // At start of texture string, put its loc in stringtable
             stringTable.Add(pos);
@@ -123,6 +127,6 @@ public sealed class BspFileWriter(BspFile file, Stream output, IoHandler? handle
             pos++;
         }
 
-        _bsp.GetLump<TexDataStringTableLump>().Data = stringTable;
+        texDataStringTableLump.Data = stringTable;
     }
 }

--- a/src/Lumper.Lib/BSP/Lumps/BspLumps/GameLump.cs
+++ b/src/Lumper.Lib/BSP/Lumps/BspLumps/GameLump.cs
@@ -21,7 +21,7 @@ public class GameLump(BspFile parent) : ManagedLump<BspLumpType>(parent)
     public T? GetLump<T>()
         where T : Lump<GameLumpType>
     {
-        return (T?)Lumps.Values.First(x => x?.GetType() == typeof(T));
+        return Lumps.Values.OfType<T>().FirstOrDefault();
     }
 
     public Lump<GameLumpType>? GetLump(GameLumpType lumpType)

--- a/src/Lumper.Lib/BSP/Lumps/BspLumps/PakFileLump.Refactoring.cs
+++ b/src/Lumper.Lib/BSP/Lumps/BspLumps/PakFileLump.Refactoring.cs
@@ -131,7 +131,7 @@ public partial class PakfileLump
     {
         bool updated = false;
 
-        foreach (Entity entity in Parent.GetLump<EntityLump>().Data)
+        foreach (Entity entity in Parent.GetLump<EntityLump>()?.Data ?? [])
         {
             foreach (Entity.EntityProperty prop in entity.Properties)
             {
@@ -415,7 +415,7 @@ public partial class PakfileLump
         if (!Path.GetExtension(oldPath).Equals(".mdl", Comparison) || !opPrefix.Equals("models", Comparison))
             return false;
 
-        List<string>? pathList = Parent.GetLump<GameLump>().GetLump<Sprp>()?.StaticPropsDict?.Data;
+        List<string>? pathList = Parent.GetLump<GameLump>()?.GetLump<Sprp>()?.StaticPropsDict?.Data;
 
         if (pathList is null)
             return false;

--- a/src/Lumper.Lib/Jobs/RemoveAssetJob.cs
+++ b/src/Lumper.Lib/Jobs/RemoveAssetJob.cs
@@ -38,7 +38,13 @@ public class RemoveAssetJob : Job, IJob
             return false;
         }
 
-        PakfileLump pakfileLump = bsp.GetLump<PakfileLump>();
+        PakfileLump? pakfileLump = bsp.GetLump<PakfileLump>();
+
+        if (pakfileLump == null)
+        {
+            Logger.Warn("BSP does not contain a pakfile lump, ignoring job.");
+            return false;
+        }
 
         Logger.Info("Removing game assets... this may take a while!");
         int totalMatches = 0;

--- a/src/Lumper.Lib/Jobs/ReplaceTextureJob.cs
+++ b/src/Lumper.Lib/Jobs/ReplaceTextureJob.cs
@@ -20,7 +20,13 @@ public class ReplaceTextureJob : Job, IJob
 
     public override bool Run(BspFile bsp)
     {
-        TexDataLump texDataLump = bsp.GetLump<TexDataLump>();
+        TexDataLump? texDataLump = bsp.GetLump<TexDataLump>();
+
+        if (texDataLump == null)
+        {
+            Logger.Warn("No TexData lump found in BSP file, ignoring job.");
+            return false;
+        }
 
         Progress.Max = texDataLump.Data.Count;
 

--- a/src/Lumper.Lib/Jobs/StripperFileJob.cs
+++ b/src/Lumper.Lib/Jobs/StripperFileJob.cs
@@ -27,7 +27,13 @@ public class StripperFileJob : Job, IJob
         var config = StripperConfig.Parse(stream);
 
         Progress.Max = config.Blocks.Count;
-        EntityLump entityLump = bsp.GetLump<EntityLump>();
+
+        EntityLump? entityLump = bsp.GetLump<EntityLump>();
+        if (entityLump == null)
+        {
+            Logger.Warn("No entity lump found, ignoring job.");
+            return false;
+        }
 
         foreach (StripperConfig.Block block in config.Blocks)
         {

--- a/src/Lumper.Lib/Jobs/StripperTextJob.cs
+++ b/src/Lumper.Lib/Jobs/StripperTextJob.cs
@@ -27,7 +27,13 @@ public class StripperTextJob : Job, IJob
         var config = StripperConfig.Parse(stream);
 
         Progress.Max = config.Blocks.Count;
-        EntityLump entityLump = bsp.GetLump<EntityLump>();
+
+        EntityLump? entityLump = bsp.GetLump<EntityLump>();
+        if (entityLump == null)
+        {
+            Logger.Warn("No entity lump found, ignoring job.");
+            return false;
+        }
 
         foreach (StripperConfig.Block block in config.Blocks)
         {

--- a/src/Lumper.Lib/RequiredGames/RequiredGames.cs
+++ b/src/Lumper.Lib/RequiredGames/RequiredGames.cs
@@ -139,7 +139,7 @@ public static class RequiredGames
     {
         List<PackedAsset> matches = [];
 
-        List<string>? props = bspFile.GetLump<GameLump>().GetLump<Sprp>()?.StaticPropsDict?.Data;
+        List<string>? props = bspFile.GetLump<GameLump>()?.GetLump<Sprp>()?.StaticPropsDict?.Data;
 
         if (props == null)
             return [];

--- a/src/Lumper.Test/PakfileRefactoringTests.cs
+++ b/src/Lumper.Test/PakfileRefactoringTests.cs
@@ -12,8 +12,8 @@ public class PakFileLumpRefactoringTests
     public void Entities_ExactMatch_UpdatesPath()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        EntityLump entityLump = bspFile.GetLump<EntityLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        EntityLump entityLump = bspFile.GetLump<EntityLump>()!;
 
         var entity = new Entity();
         entity.Properties.Add(new Entity.EntityProperty<string>("model", "models/test/example.mdl"));
@@ -38,8 +38,8 @@ public class PakFileLumpRefactoringTests
     public void Entities_WithoutDirectoryMatch_UpdatesPath()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        EntityLump entityLump = bspFile.GetLump<EntityLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        EntityLump entityLump = bspFile.GetLump<EntityLump>()!;
 
         var entity = new Entity();
         entity.Properties.Add(new Entity.EntityProperty<string>("sound", "test/sound.wav"));
@@ -64,8 +64,8 @@ public class PakFileLumpRefactoringTests
     public void Entities_NoMatches_ReturnsEmpty()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        EntityLump entityLump = bspFile.GetLump<EntityLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        EntityLump entityLump = bspFile.GetLump<EntityLump>()!;
 
         var entity = new Entity();
         entity.Properties.Add(new Entity.EntityProperty<string>("model", "models/different/example.mdl"));
@@ -84,8 +84,8 @@ public class PakFileLumpRefactoringTests
     public void Entities_MultipleEntities_UpdatesAllMatches()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        EntityLump entityLump = bspFile.GetLump<EntityLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        EntityLump entityLump = bspFile.GetLump<EntityLump>()!;
 
         var entity1 = new Entity();
         entity1.Properties.Add(new Entity.EntityProperty<string>("model", "models/test/example.mdl"));
@@ -119,8 +119,8 @@ public class PakFileLumpRefactoringTests
     public void Entities_NonStringProperty_DoesNotUpdate()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        EntityLump entityLump = bspFile.GetLump<EntityLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        EntityLump entityLump = bspFile.GetLump<EntityLump>()!;
 
         var entity = new Entity();
         _ = EntityIo.TryParse("a,b,c,0,1", out EntityIo? entityIo);
@@ -140,8 +140,8 @@ public class PakFileLumpRefactoringTests
     public void Entities_CrossDirectoryMove_ReturnsEmpty()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        EntityLump entityLump = bspFile.GetLump<EntityLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        EntityLump entityLump = bspFile.GetLump<EntityLump>()!;
 
         var entity = new Entity();
         entity.Properties.Add(new Entity.EntityProperty<string>("model", "models/test/example.mdl"));
@@ -162,8 +162,8 @@ public class PakFileLumpRefactoringTests
     public void Entities_BackSlash_UpdatesPath()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        EntityLump entityLump = bspFile.GetLump<EntityLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        EntityLump entityLump = bspFile.GetLump<EntityLump>()!;
 
         var entity = new Entity();
         entity.Properties.Add(new Entity.EntityProperty<string>("model", @"models\test\example.mdl"));
@@ -187,8 +187,8 @@ public class PakFileLumpRefactoringTests
     public void Entities_MixedSlash_UpdatesPath()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        EntityLump entityLump = bspFile.GetLump<EntityLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        EntityLump entityLump = bspFile.GetLump<EntityLump>()!;
 
         var entity = new Entity();
         entity.Properties.Add(new Entity.EntityProperty<string>("model", @"models\test/example.mdl"));
@@ -212,8 +212,8 @@ public class PakFileLumpRefactoringTests
     public void Entities_CaseInsensitiveMatch_UpdatesPath()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        EntityLump entityLump = bspFile.GetLump<EntityLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        EntityLump entityLump = bspFile.GetLump<EntityLump>()!;
 
         var entity = new Entity();
         entity.Properties.Add(new Entity.EntityProperty<string>("model", "Models/Test/Example.mdl"));
@@ -237,8 +237,8 @@ public class PakFileLumpRefactoringTests
     public void Entities_MultipleProperties_UpdatesAllMatches()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        EntityLump entityLump = bspFile.GetLump<EntityLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        EntityLump entityLump = bspFile.GetLump<EntityLump>()!;
 
         var entity = new Entity();
         entity.Properties.Add(new Entity.EntityProperty<string>("model", "models/test/example.mdl"));
@@ -269,8 +269,8 @@ public class PakFileLumpRefactoringTests
     public void Entities_PartialPathMatch_DoesNotUpdate()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        EntityLump entityLump = bspFile.GetLump<EntityLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        EntityLump entityLump = bspFile.GetLump<EntityLump>()!;
 
         var entity = new Entity();
         entity.Properties.Add(new Entity.EntityProperty<string>("model", "models/test/example_extra.mdl"));
@@ -291,8 +291,8 @@ public class PakFileLumpRefactoringTests
     public void Entities_SoundPathWithoutPrefix_UpdatesPath()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        EntityLump entityLump = bspFile.GetLump<EntityLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        EntityLump entityLump = bspFile.GetLump<EntityLump>()!;
 
         var entity = new Entity();
         entity.Properties.Add(new Entity.EntityProperty<string>("message", "ambient/water/drip1.wav"));
@@ -316,8 +316,8 @@ public class PakFileLumpRefactoringTests
     public void Entities_NoSeparators_ReturnsEmpty()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        EntityLump entityLump = bspFile.GetLump<EntityLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        EntityLump entityLump = bspFile.GetLump<EntityLump>()!;
 
         var entity = new Entity();
         entity.Properties.Add(new Entity.EntityProperty<string>("message", "filename.wav"));
@@ -1009,7 +1009,7 @@ public class PakFileLumpRefactoringTests
     )
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
 
         TestUtils.AddPakfileEntry(pakfileLump, fileName, inData);
 
@@ -1033,7 +1033,7 @@ public class PakFileLumpRefactoringTests
     public void Pakfile_MultiplePakfileEntries_UpdatesAllMatches()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
 
         const string content1 = """
             "VertexLitGeneric"
@@ -1086,8 +1086,8 @@ public class PakFileLumpRefactoringTests
     public void TexData_ExactMatch_UpdatesPath()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        TexDataLump texDataLump = bspFile.GetLump<TexDataLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        TexDataLump texDataLump = bspFile.GetLump<TexDataLump>()!;
 
         var texData = new TexData { TexName = "test/example" };
         texDataLump.Data.Add(texData);
@@ -1109,8 +1109,8 @@ public class PakFileLumpRefactoringTests
     public void TexData_NoMatch_ReturnsEmpty()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        TexDataLump texDataLump = bspFile.GetLump<TexDataLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        TexDataLump texDataLump = bspFile.GetLump<TexDataLump>()!;
 
         var texData = new TexData { TexName = "test/different" };
         texDataLump.Data.Add(texData);
@@ -1132,8 +1132,8 @@ public class PakFileLumpRefactoringTests
     public void TexData_CaseInsensitiveMatch_UpdatesPath()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        TexDataLump texDataLump = bspFile.GetLump<TexDataLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        TexDataLump texDataLump = bspFile.GetLump<TexDataLump>()!;
 
         var texData = new TexData { TexName = "TEST/EXAMPLE" };
         texDataLump.Data.Add(texData);
@@ -1155,8 +1155,8 @@ public class PakFileLumpRefactoringTests
     public void TexData_NonVmtExtension_ReturnsEmpty()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        TexDataLump texDataLump = bspFile.GetLump<TexDataLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        TexDataLump texDataLump = bspFile.GetLump<TexDataLump>()!;
 
         var texData = new TexData { TexName = "test/example" };
         texDataLump.Data.Add(texData);
@@ -1178,8 +1178,8 @@ public class PakFileLumpRefactoringTests
     public void TexData_NonMaterialsPrefix_ReturnsEmpty()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        TexDataLump texDataLump = bspFile.GetLump<TexDataLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        TexDataLump texDataLump = bspFile.GetLump<TexDataLump>()!;
 
         var texData = new TexData { TexName = "test/example" };
         texDataLump.Data.Add(texData);
@@ -1201,8 +1201,8 @@ public class PakFileLumpRefactoringTests
     public void TexData_MultipleMatches_UpdatesAllPaths()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        TexDataLump texDataLump = bspFile.GetLump<TexDataLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        TexDataLump texDataLump = bspFile.GetLump<TexDataLump>()!;
 
         var texData1 = new TexData { TexName = "test/example" };
         var texData2 = new TexData { TexName = "test/example" };
@@ -1230,9 +1230,9 @@ public class PakFileLumpRefactoringTests
     public void TexData_UpdatesPathAlongWithOtherTypes()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        TexDataLump texDataLump = bspFile.GetLump<TexDataLump>();
-        EntityLump entityLump = bspFile.GetLump<EntityLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        TexDataLump texDataLump = bspFile.GetLump<TexDataLump>()!;
+        EntityLump entityLump = bspFile.GetLump<EntityLump>()!;
 
         // Add TexData entry
         var texData = new TexData { TexName = "test/example" };
@@ -1296,8 +1296,8 @@ public class PakFileLumpRefactoringTests
     public void StaticProp_ExactMatch_UpdatesPath()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        GameLump gameLump = bspFile.GetLump<GameLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        GameLump gameLump = bspFile.GetLump<GameLump>()!;
         Sprp sprpLump = gameLump.GetLump<Sprp>()!;
         sprpLump.StaticPropsDict!.Data.Add("models/test/example.mdl");
 
@@ -1318,8 +1318,8 @@ public class PakFileLumpRefactoringTests
     public void StaticProp_NoMatch_ReturnsEmpty()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        GameLump gameLump = bspFile.GetLump<GameLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        GameLump gameLump = bspFile.GetLump<GameLump>()!;
         Sprp sprpLump = gameLump.GetLump<Sprp>()!;
         sprpLump.StaticPropsDict!.Data.Add("models/test/different.mdl");
 
@@ -1340,8 +1340,8 @@ public class PakFileLumpRefactoringTests
     public void StaticProp_CaseInsensitiveMatch_UpdatesPath()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        GameLump gameLump = bspFile.GetLump<GameLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        GameLump gameLump = bspFile.GetLump<GameLump>()!;
         Sprp sprpLump = gameLump.GetLump<Sprp>()!;
         sprpLump.StaticPropsDict!.Data.Add("MODELS/TEST/EXAMPLE.MDL");
 
@@ -1362,8 +1362,8 @@ public class PakFileLumpRefactoringTests
     public void StaticProp_NonMdlExtension_ReturnsEmpty()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        GameLump gameLump = bspFile.GetLump<GameLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        GameLump gameLump = bspFile.GetLump<GameLump>()!;
         Sprp sprpLump = gameLump.GetLump<Sprp>()!;
         sprpLump.StaticPropsDict!.Data.Add("models/test/example.mdl");
 
@@ -1384,8 +1384,8 @@ public class PakFileLumpRefactoringTests
     public void StaticProp_NonModelsPrefix_ReturnsEmpty()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        GameLump gameLump = bspFile.GetLump<GameLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        GameLump gameLump = bspFile.GetLump<GameLump>()!;
         Sprp sprpLump = gameLump.GetLump<Sprp>()!;
         sprpLump.StaticPropsDict!.Data.Add("models/test/example.mdl");
 
@@ -1408,8 +1408,8 @@ public class PakFileLumpRefactoringTests
     public void StaticProp_MultipleModels_UpdatesMatchingOne()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        GameLump gameLump = bspFile.GetLump<GameLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        GameLump gameLump = bspFile.GetLump<GameLump>()!;
         Sprp sprpLump = gameLump.GetLump<Sprp>()!;
         sprpLump.StaticPropsDict!.Data.Add("models/test/example.mdl");
         sprpLump.StaticPropsDict.Data.Add("models/test/different.mdl");
@@ -1435,8 +1435,8 @@ public class PakFileLumpRefactoringTests
     public void StaticProp_BackslashInPath_ReturnsEmpty()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        GameLump gameLump = bspFile.GetLump<GameLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        GameLump gameLump = bspFile.GetLump<GameLump>()!;
         Sprp sprpLump = gameLump.GetLump<Sprp>()!;
         sprpLump.StaticPropsDict!.Data.Add(@"models\test\example.mdl");
 
@@ -1457,8 +1457,8 @@ public class PakFileLumpRefactoringTests
     public void StaticProp_NullStaticPropDict_ReturnsEmpty()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        GameLump gameLump = bspFile.GetLump<GameLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        GameLump gameLump = bspFile.GetLump<GameLump>()!;
         Sprp sprpLump = gameLump.GetLump<Sprp>()!;
         sprpLump.StaticPropsDict = null;
 
@@ -1475,9 +1475,9 @@ public class PakFileLumpRefactoringTests
     public void StaticProp_UpdatesPathAlongWithOtherTypes()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
-        GameLump gameLump = bspFile.GetLump<GameLump>();
-        EntityLump entityLump = bspFile.GetLump<EntityLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
+        GameLump gameLump = bspFile.GetLump<GameLump>()!;
+        EntityLump entityLump = bspFile.GetLump<EntityLump>()!;
 
         // Add StaticProp entry
         Sprp sprpLump = gameLump.GetLump<Sprp>()!;
@@ -1508,7 +1508,7 @@ public class PakFileLumpRefactoringTests
     public void ProcessMapRename_MaterialsMapsPath_RenamesFile()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
 
         TestUtils.AddPakfileEntry(pakfileLump, "materials/maps/surf_utopia/cubemapdefault.vmt");
         pakfileLump.IsModified = false; // Creating new PakFileEntry from stream sets IsModified to true, so we reset it.
@@ -1526,7 +1526,7 @@ public class PakFileLumpRefactoringTests
     public void ProcessMapRename_SoundscapesTxtFile_RenamesFile()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
 
         TestUtils.AddPakfileEntry(pakfileLump, "scripts/soundscapes_kz_example.txt");
         pakfileLump.IsModified = false;
@@ -1544,7 +1544,7 @@ public class PakFileLumpRefactoringTests
     public void ProcessMapRename_SoundscapesVscFile_RenamesFile()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
 
         TestUtils.AddPakfileEntry(pakfileLump, "scripts/soundscapes_bhop_forest.vsc");
         pakfileLump.IsModified = false;
@@ -1562,7 +1562,7 @@ public class PakFileLumpRefactoringTests
     public void ProcessMapRename_LevelSoundsFile_RenamesFile()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
 
         TestUtils.AddPakfileEntry(pakfileLump, "maps/surf_mesa_level_sounds.txt");
         pakfileLump.IsModified = false;
@@ -1580,7 +1580,7 @@ public class PakFileLumpRefactoringTests
     public void ProcessMapRename_ParticlesFile_RenamesFile()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
 
         TestUtils.AddPakfileEntry(pakfileLump, "maps/kz_climb_particles.txt");
         pakfileLump.IsModified = false;
@@ -1598,7 +1598,7 @@ public class PakFileLumpRefactoringTests
     public void ProcessMapRename_MultipleDifferentFiles_RenamesAllMatchingFiles()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
 
         // Add multiple different types of files
         TestUtils.AddPakfileEntry(pakfileLump, "materials/maps/surf_y/texture.vmt");
@@ -1625,7 +1625,7 @@ public class PakFileLumpRefactoringTests
     public void ProcessMapRename_CaseInsensitiveMapName_RenamesFile()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
 
         // Add pakfile entry with differently cased map name
         TestUtils.AddPakfileEntry(pakfileLump, "materials/maps/SURF_UTOPIA/texture.vmt");
@@ -1644,7 +1644,7 @@ public class PakFileLumpRefactoringTests
     public void ProcessMapRename_NoMatchingFiles_DoesNothing()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
 
         TestUtils.AddPakfileEntry(pakfileLump, "materials/models/props/barrel.vmt");
         pakfileLump.IsModified = false;
@@ -1662,7 +1662,7 @@ public class PakFileLumpRefactoringTests
     public void ProcessMapRename_MaterialsWithSubfolders_RenamesFile()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
 
         TestUtils.AddPakfileEntry(pakfileLump, "materials/maps/surf_utopia/subfolder/texture.vmt");
         pakfileLump.IsModified = false;
@@ -1680,7 +1680,7 @@ public class PakFileLumpRefactoringTests
     public void ProcessMapRename_PartialMapNameMatch_DoesNotRename()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
 
         // Add entry with a name that contains the map name as a substring
         TestUtils.AddPakfileEntry(pakfileLump, "materials/maps/surf_utopia2/texture.vmt");
@@ -1699,7 +1699,7 @@ public class PakFileLumpRefactoringTests
     public void ProcessMapRename_DifferentMapName_DoesNotRename()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
 
         TestUtils.AddPakfileEntry(pakfileLump, "materials/maps/surf_different/texture.vmt");
         pakfileLump.IsModified = false;
@@ -1717,7 +1717,7 @@ public class PakFileLumpRefactoringTests
     public void ProcessMapRename_SimilarButDifferentPaths_DoesNotRename()
     {
         BspFile bspFile = TestUtils.CreateMockBspFile();
-        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>();
+        PakfileLump pakfileLump = bspFile.GetLump<PakfileLump>()!;
 
         // Add entries with similar but different paths
         TestUtils.AddPakfileEntry(pakfileLump, "materials/maps_custom/surf_utopia/texture.vmt");

--- a/src/Lumper.Test/RemoveAssetJobTests.cs
+++ b/src/Lumper.Test/RemoveAssetJobTests.cs
@@ -18,7 +18,7 @@ public class RemoveAssetJobTests
     {
         // Create mock BSP file
         _bspFile = TestUtils.CreateMockBspFile();
-        _pakfileLump = _bspFile.GetLump<PakfileLump>();
+        _pakfileLump = _bspFile.GetLump<PakfileLump>()!;
 
         // Clear any existing entries
         _pakfileLump.Entries.Clear();

--- a/src/Lumper.Test/StripperConfigTest.cs
+++ b/src/Lumper.Test/StripperConfigTest.cs
@@ -19,7 +19,7 @@ public class StripperConfigTests
     public void Setup()
     {
         _bspFile = TestUtils.CreateMockBspFile();
-        _entityLump = _bspFile.GetLump<EntityLump>();
+        _entityLump = _bspFile.GetLump<EntityLump>()!;
 
         // Clear any entities that might be in the lump
         _entityLump.Data.Clear();

--- a/src/Lumper.UI/Services/BspService.cs
+++ b/src/Lumper.UI/Services/BspService.cs
@@ -142,7 +142,7 @@ public sealed class BspService : ReactiveObject, IDisposable
                 IEnumerable<Lump> lumps =
                 [
                     .. bsp.Lumps.Values.Where(y => y.Type != BspLumpType.GameLump),
-                    .. bsp.GetLump<GameLump>().Lumps.Values.OfType<Lump>(),
+                    .. bsp.GetLump<GameLump>()?.Lumps.Values.OfType<Lump>() ?? [],
                 ];
                 var nonEmpty = lumps.Where(y => !y.Empty).ToList();
                 CompressedLumps = nonEmpty.Sum(y => y.IsCompressed ? 1 : 0);

--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
@@ -235,7 +235,7 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
             // basically anything modifyable in the UI whilst refactor is ongoing. Would prefer to avoid to UI
             // lag, but too much work blocking modification everywhere.
             List<PakfileLump.PathReferenceUpdateType> updated = await Observable.Start(
-                () => BspService.Instance.BspFile!.GetLump<PakfileLump>().UpdatePathReferences(oldKey, newKey),
+                () => BspService.Instance.BspFile!.GetLump<PakfileLump>()!.UpdatePathReferences(oldKey, newKey),
                 RxApp.MainThreadScheduler
             );
 

--- a/src/Lumper.UI/ViewModels/Shared/Entity/EntityLumpViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Entity/EntityLumpViewModel.cs
@@ -44,7 +44,9 @@ public sealed class EntityLumpViewModel : LumpViewModel
     {
         BspService.Instance.ThrowIfNoLoadedBsp();
 
-        _entityLump = bsp.GetLump<EntityLump>();
+        _entityLump =
+            bsp.GetLump<EntityLump>()
+            ?? throw new InvalidOperationException("BSP file does not contain an Entity lump somehow!");
 
         LoadEntityList();
 

--- a/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileLumpViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileLumpViewModel.cs
@@ -25,7 +25,9 @@ public sealed class PakfileLumpViewModel : LumpViewModel
     {
         BspService.Instance.ThrowIfNoLoadedBsp();
 
-        _pakfile = bsp.GetLump<PakfileLump>();
+        _pakfile =
+            bsp.GetLump<PakfileLump>()
+            ?? throw new InvalidOperationException("BSP does not contain a pakfile lump somehow!");
 
         PullChangesFromModel(); // Initializes everything
     }


### PR DESCRIPTION
`BspFile.GetLump<T>` should return `T?`, not `T`. Took quite a bit of refactoring!