### PR TITLE
Update BSP hash after saving

### DIFF
--- a/src/Lumper.Lib/BSP/BspFile.cs
+++ b/src/Lumper.Lib/BSP/BspFile.cs
@@ -295,6 +295,7 @@ public sealed partial class BspFile : IDisposable
             FilePath = outPath;
             FileStream = File.OpenRead(outPath);
             FileSize = new FileInfo(outPath).Length;
+            ComputeHash(FileStream);
 
             Logger.Info($"Saved {outPath}");
 

--- a/src/Lumper.UI/Services/GameSyncService.cs
+++ b/src/Lumper.UI/Services/GameSyncService.cs
@@ -164,7 +164,7 @@ public sealed class GameSyncService : ReactiveObject, IDisposable
             if (_lastWarnedHash != message.MapHash)
             {
                 _logger.Warn(
-                    "Received game message with mismatching map hash! You are probably editing the wrong map."
+                    "Received game message with mismatching map hash! You are editing the wrong map or haven't reloaded in-game after saving."
                 );
                 _logger.Warn($"Lumper map hash: {BspService.Instance.FileHash}, game map hash: {message.MapHash}");
                 _lastWarnedHash = message.MapHash;


### PR DESCRIPTION
Stops game sync from yelling at you if you save a map in Lumper then reload it in-game.