### PR TITLE
Fix default sorting of entity rules page

### DIFF
--- a/src/Lumper.UI/Views/Pages/EntityReview/EntityReviewView.axaml
+++ b/src/Lumper.UI/Views/Pages/EntityReview/EntityReviewView.axaml
@@ -20,7 +20,7 @@
       </Button>
     </Grid>
     <DataGrid Grid.Row="1" ItemsSource="{Binding Results}" IsReadOnly="True" BorderBrush="#333"
-              BorderThickness="0 1 0 0" VerticalScrollBarVisibility="Visible">
+              BorderThickness="0 1 0 0" VerticalScrollBarVisibility="Visible" CanUserSortColumns="False">
       <DataGrid.Styles>
         <Style Selector="ScrollBar">
           <Setter Property="AllowAutoHide" Value="False" />
@@ -32,7 +32,7 @@
                             FontFamily="{StaticResource Monospace}" FontSize="14" />
         <DataGridTextColumn Width="Auto" Header="Count" Binding="{Binding Count}"
                             FontFamily="{StaticResource Monospace}" FontSize="14" />
-        <DataGridTemplateColumn Width="Auto" Header="Validity" SortMemberPath="Level">
+        <DataGridTemplateColumn Width="Auto" Header="Validity">
           <DataGridTemplateColumn.CellTemplate>
             <DataTemplate>
               <Panel VerticalAlignment="Stretch">


### PR DESCRIPTION
Ensures that grid is always sorted by Level, then Classname. DataGrid sorting is a huge pain, can't get it to stop resetting every time you switch to the page, so disabled sorting by pressing column headers completely. If we really wanted it, we might have to roll our own approach handling the header pressed events and storing which header is currently sorted by in the viewmodel.