### PR TITLE
Texture Resizing and Re-encoding

### DIFF
--- a/src/Lumper.Lib/RequiredGames/RequiredGames.cs
+++ b/src/Lumper.Lib/RequiredGames/RequiredGames.cs
@@ -1,6 +1,5 @@
 ﻿namespace Lumper.Lib.RequiredGames;
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryVtfViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Shared/Pakfile/PakfileEntryVtfViewModel.cs
@@ -20,6 +20,7 @@ using ReactiveUI.Fody.Helpers;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Bmp;
 using SixLabors.ImageSharp.PixelFormats;
+using VTFLib;
 
 public class PakfileEntryVtfViewModel : PakfileEntryViewModel
 {
@@ -61,6 +62,11 @@ public class PakfileEntryVtfViewModel : PakfileEntryViewModel
 
     public uint[] ResizeOptions { get; } = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096];
 
+    [Reactive]
+    public VTFImageFormat SelectedImageFormat { get; set; }
+
+    public VTFImageFormat[] ImageFormats { get; } = Enum.GetValues<VTFImageFormat>();
+
     public bool HasSeparateWindow { get; set; }
 
     public PakfileEntryVtfViewModel(PakfileEntry entry, BspNode parent)
@@ -87,6 +93,8 @@ public class PakfileEntryVtfViewModel : PakfileEntryViewModel
             .Skip(1)
             .ObserveOn(RxApp.TaskpoolScheduler)
             .Subscribe(x => _ = FetchImage());
+
+        this.WhenAnyValue(x => x.VtfFile, x => x.VtfFile!.ImageFormat).Subscribe(x => SelectedImageFormat = x.Item2);
     }
 
     private bool _inited;
@@ -189,6 +197,15 @@ public class PakfileEntryVtfViewModel : PakfileEntryViewModel
                 }
             }
         }
+    }
+
+    public async Task Reencode()
+    {
+        if (VtfFile is null)
+            return;
+
+        await VtfFile.Reencode(SelectedImageFormat, Frame, Face, Slice, MipmapLevel);
+        await FetchImage();
     }
 
     public void OpenVtfImageWindow()

--- a/src/Lumper.UI/Views/Pages/VtfBrowser/VtfBrowserView.axaml
+++ b/src/Lumper.UI/Views/Pages/VtfBrowser/VtfBrowserView.axaml
@@ -6,9 +6,14 @@
              xmlns:materialIcons="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              xmlns:views="clr-namespace:Lumper.UI.Views.Pages.VtfBrowser"
              xmlns:vm="clr-namespace:Lumper.UI.ViewModels.Pages.VtfBrowser"
+             xmlns:converters="clr-namespace:Lumper.UI.Converters"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="vm:VtfBrowserViewModel"
              x:Class="Lumper.UI.Views.Pages.VtfBrowser.VtfBrowserView">
+
+  <UserControl.Resources>
+    <converters:FileSizeConverter x:Key="FileSize" />
+  </UserControl.Resources>
 
   <Grid RowDefinitions="*, Auto">
     <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
@@ -31,7 +36,8 @@
               </Button.ContextMenu>
               <Panel>
                 <StackPanel ZIndex="10" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="8"
-                            Orientation="Horizontal" IsVisible="{Binding !!MatchingGameAssets.Count}" Background="#88000000">
+                            Orientation="Horizontal" IsVisible="{Binding !!MatchingGameAssets.Count}"
+                            Background="#88000000">
                   <ToolTip.Tip>
                     <StackPanel Spacing="4">
                       <TextBlock Text="This texture is present in a Valve game or other asset pack!" />
@@ -62,26 +68,44 @@
                   <materialIcons:MaterialIcon Width="20" Height="20" Kind="AlertCircleOutline" Foreground="Red"
                                               Margin="4 3 6 4" HorizontalAlignment="Center" VerticalAlignment="Center" />
                 </StackPanel>
-                <StackPanel
-                    Height="{Binding ViewModel.StateService.VtfBrowserDimensions, RelativeSource={RelativeSource AncestorType=views:VtfBrowserView}, FallbackValue=192}"
-                    Width="{Binding ViewModel.StateService.VtfBrowserDimensions, RelativeSource={RelativeSource AncestorType=views:VtfBrowserView}, FallbackValue=192}">
+                <Panel
+                  Height="{Binding ViewModel.StateService.VtfBrowserDimensions, RelativeSource={RelativeSource AncestorType=views:VtfBrowserView}, FallbackValue=192}"
+                  Width="{Binding ViewModel.StateService.VtfBrowserDimensions, RelativeSource={RelativeSource AncestorType=views:VtfBrowserView}, FallbackValue=192}">
                   <Image
                     Height="{Binding ViewModel.StateService.VtfBrowserDimensions, RelativeSource={RelativeSource AncestorType=views:VtfBrowserView}, FallbackValue=192}"
                     Width="{Binding ViewModel.StateService.VtfBrowserDimensions, RelativeSource={RelativeSource AncestorType=views:VtfBrowserView}, FallbackValue=192}"
                     Source="{Binding Image}" IsVisible="{Binding Loaded}">
                   </Image>
-                  <TextBlock
-                    TextTrimming="CharacterEllipsis" HorizontalAlignment="Center" VerticalAlignment="Bottom"
-                    Text="{Binding Name}" Padding="4"
-                    MaxWidth="{Binding ViewModel.StateService.VtfBrowserDimensions, RelativeSource={RelativeSource AncestorType=views:VtfBrowserView}, FallbackValue=192}">
-                    <ToolTip.Tip>
-                      <StackPanel Width="600">
-                        <TextBlock Text="{Binding Name}" />
-                        <TextBlock Text="{Binding Key}" />
-                      </StackPanel>
-                    </ToolTip.Tip>
-                  </TextBlock>
-                </StackPanel>
+
+                  <Border HorizontalAlignment="Stretch" VerticalAlignment="Bottom" Margin="4" Padding="2"
+                          Background="#88000000" CornerRadius="2">
+                    <StackPanel Spacing="4" Orientation="Vertical" HorizontalAlignment="Center">
+                      <TextBlock
+                        TextTrimming="CharacterEllipsis" HorizontalAlignment="Center" VerticalAlignment="Bottom"
+                        Text="{Binding Name}" FontFamily="{StaticResource Monospace}"
+                        MaxWidth="{Binding ViewModel.StateService.VtfBrowserDimensions, RelativeSource={RelativeSource AncestorType=views:VtfBrowserView}, FallbackValue=192}">
+                        <TextBlock.Effect>
+                          <DropShadowEffect Color="Black" BlurRadius="0" OffsetX="1" OffsetY="1" />
+                        </TextBlock.Effect>
+                        <ToolTip.Tip>
+                          <StackPanel Width="600">
+                            <TextBlock Text="{Binding Name}" />
+                            <TextBlock Text="{Binding Key}" />
+                          </StackPanel>
+                        </ToolTip.Tip>
+                      </TextBlock>
+                      <TextBlock
+                        TextTrimming="CharacterEllipsis" HorizontalAlignment="Center" VerticalAlignment="Bottom"
+                        Text="{Binding UncompressedSize, Converter={StaticResource FileSize}}"
+                        Foreground="{Binding WarningColor}" FontFamily="{StaticResource Monospace}"
+                        MaxWidth="{Binding ViewModel.StateService.VtfBrowserDimensions, RelativeSource={RelativeSource AncestorType=views:VtfBrowserView}, FallbackValue=192}">
+                        <TextBlock.Effect>
+                          <DropShadowEffect Color="Black" BlurRadius="0" OffsetX="1" OffsetY="1" />
+                        </TextBlock.Effect>
+                      </TextBlock>
+                    </StackPanel>
+                  </Border>
+                </Panel>
               </Panel>
             </Button>
           </DataTemplate>
@@ -92,7 +116,7 @@
     <Border Grid.Row="1" BorderBrush="#10FFFFFF" Background="#20000000" Padding="4" BorderThickness="0 1 0 0">
       <Grid ColumnDefinitions="Auto, Auto, Auto, Auto, *, Auto, Auto">
         <ctrls:ClearableTextBox Grid.Column="0" Height="32" Width="256" Margin="8" Text="{Binding TextureSearch}"
-                 Watermark="Search" />
+                                Watermark="Search" />
         <CheckBox Grid.Column="1" Margin="4" VerticalAlignment="Center" HorizontalAlignment="Stretch"
                   IsChecked="{Binding StateService.VtfBrowserShowCubemaps, Mode=TwoWay}">
           Show Cubemaps

--- a/src/Lumper.UI/Views/Shared/Pakfile/PakfileEntryVtfView.axaml
+++ b/src/Lumper.UI/Views/Shared/Pakfile/PakfileEntryVtfView.axaml
@@ -146,10 +146,7 @@
                            Minimum="0" Maximum="{Binding MipmapMax}" />
           </Grid>
 
-          <Button Command="{Binding Resize}" Margin="0 8 0 0">
-            <TextBlock Text="Resize (Width x Height)" />
-          </Button>
-          <StackPanel Orientation="Horizontal" Spacing="4" Margin="0 0 0 8">
+          <StackPanel Orientation="Horizontal" Spacing="4" Margin="0 8 0 0">
             <ComboBox ItemsSource="{Binding ResizeOptions}" SelectedItem="{Binding SelectedResizeWidth}"
                       Padding="12,0,0,0">
               <ComboBox.ItemTemplate>
@@ -167,6 +164,23 @@
               </ComboBox.ItemTemplate>
             </ComboBox>
           </StackPanel>
+          <Button Command="{Binding Resize}" Margin="0 0 0 4">
+            <TextBlock Text="Resize (Width x Height)" />
+          </Button>
+
+          <StackPanel Orientation="Horizontal" Spacing="4">
+            <ComboBox ItemsSource="{Binding ImageFormats}" SelectedItem="{Binding SelectedImageFormat}"
+                      Padding="12,0,0,0">
+              <ComboBox.ItemTemplate>
+                <DataTemplate>
+                  <TextBlock Classes="Value" Text="{Binding}" />
+                </DataTemplate>
+              </ComboBox.ItemTemplate>
+            </ComboBox>
+          </StackPanel>
+          <Button Command="{Binding Reencode}" Margin="0 0 0 8">
+            <TextBlock Text="Re-encode" />
+          </Button>
 
           <Button Command="{Binding SetImage}" CommandParameter="true">Replace Image</Button>
           <Button Command="{Binding SetImage}" CommandParameter="false"

--- a/src/Lumper.UI/Views/Shared/Pakfile/PakfileEntryVtfView.axaml
+++ b/src/Lumper.UI/Views/Shared/Pakfile/PakfileEntryVtfView.axaml
@@ -146,6 +146,28 @@
                            Minimum="0" Maximum="{Binding MipmapMax}" />
           </Grid>
 
+          <Button Command="{Binding Resize}" Margin="0 8 0 0">
+            <TextBlock Text="Resize (Width x Height)" />
+          </Button>
+          <StackPanel Orientation="Horizontal" Spacing="4" Margin="0 0 0 8">
+            <ComboBox ItemsSource="{Binding ResizeOptions}" SelectedItem="{Binding SelectedResizeWidth}"
+                      Padding="12,0,0,0">
+              <ComboBox.ItemTemplate>
+                <DataTemplate>
+                  <TextBlock Classes="Value" Text="{Binding}" />
+                </DataTemplate>
+              </ComboBox.ItemTemplate>
+            </ComboBox>
+            <ComboBox ItemsSource="{Binding ResizeOptions}" SelectedItem="{Binding SelectedResizeHeight}"
+                      Padding="12,0,0,0">
+              <ComboBox.ItemTemplate>
+                <DataTemplate>
+                  <TextBlock Classes="Value" Text="{Binding}" />
+                </DataTemplate>
+              </ComboBox.ItemTemplate>
+            </ComboBox>
+          </StackPanel>
+
           <Button Command="{Binding SetImage}" CommandParameter="true">Replace Image</Button>
           <Button Command="{Binding SetImage}" CommandParameter="false"
                   ToolTip.Tip="Replace only the current Frame, Face, Slice and Mipmap">


### PR DESCRIPTION
Closes https://github.com/momentum-mod/lumper/issues/192

- Adds texture resizing
- Adds texture encoding
- Adds texture name and file size to texture browser view, with color coding for very large textures
- Updates VTFLib.NET's binaries to use latest from Strata's fork, which includes support for BC7, which will be our recommendation for practically all re-encoded textures

Tested everything out on a couple of maps, seems to work perfectly. UI autpmatically updates to show new sizes with is really nice.

<img width="1920" height="1023" alt="image" src="https://github.com/user-attachments/assets/a059701c-c21a-4f0e-b405-1465cb58f630" />
<img width="893" height="830" alt="image" src="https://github.com/user-attachments/assets/74b465fa-38ab-4c68-85cc-19a05d4ea372" />
