### PR TITLE
Update entity rules to allow env_wind

### DIFF
--- a/resources/EntityRules_Momentum.json
+++ b/resources/EntityRules_Momentum.json
@@ -230,8 +230,8 @@
         "Comment": "Use with care, don't punch the player's view if it affects gameplay"
     },
     "env_wind": {
-        "Level": 0,
-        "Comment": "Used with physics entities, wind carries over between maps"
+        "Level": 2,
+        "Comment": "Ensure it doesn't affect physics props"
     },
     "env_zoom": {
         "Level": 3


### PR DESCRIPTION
Brae did significant work improving `env_wind`, dust, ropes etc on Strata in late 2021, fine to allow in maps unless they move physics props around.