### PR TITLE
Added toggle button to the PakFileEditor to show compressed values

### DIFF
--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
@@ -156,10 +156,6 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
     {
         ShowCompressedSize = !ShowCompressedSize;
         Tree?.Root.NotifyDisplaySizeChanged();
-        if (Tree is not null)
-        {
-            DataGridSource = CreateHierarchicalTreeDataGridSource();
-        }
     }
 
     public void ExpandAll()

--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
@@ -78,7 +78,7 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
         {
             throw new InvalidOperationException("Tree root cannot be null when creating data grid source");
         }
-            
+
         return new HierarchicalTreeDataGridSource<Node>(Tree.Root)
         {
             Columns =

--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
@@ -155,6 +155,7 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
     public void ToggleSizeDisplay()
     {
         ShowCompressedSize = !ShowCompressedSize;
+        DataGridSource = CreateHierarchicalTreeDataGridSource();
         Tree?.Root.NotifyDisplaySizeChanged();
     }
 

--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileExplorerViewModel.cs
@@ -35,6 +35,9 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
     [Reactive]
     public PakfileEntryViewModel? ActiveFile { get; set; }
 
+    [Reactive]
+    public bool ShowCompressedSize { get; set; } = false;
+
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
     public PakfileExplorerViewModel()
@@ -53,67 +56,79 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
                 }
 
                 _pakfileLumpViewModel = pakfile;
-                Tree = new PakfileTreeViewModel(pakfile.Entries);
+                Tree = new PakfileTreeViewModel(pakfile.Entries, this);
 
-                DataGridSource = new HierarchicalTreeDataGridSource<Node>(Tree.Root)
+                if (Tree is not null)
                 {
-                    Columns =
-                    {
-                        new HierarchicalExpanderColumn<Node>(
-                            new TemplateColumn<Node>(
-                                "Name",
-                                "EntryNameCell",
-                                null, // No edit cell, doesn't work well, we use dialog window instead
-                                new GridLength(4, GridUnitType.Star),
-                                new TemplateColumnOptions<Node>
-                                {
-                                    CompareAscending = Node.SortAscending(x => x.Name),
-                                    CompareDescending = Node.SortDescending(x => x.Name),
-                                    IsTextSearchEnabled = true,
-                                    TextSearchValueSelector = x => x.Name,
-                                    BeginEditGestures = BeginEditGestures.None,
-                                }
-                            ),
-                            x => x.Children,
-                            x => x.IsDirectory,
-                            x => x.IsExpanded
-                        ),
-                        new TextColumn<Node, string?>(
-                            "Extension",
-                            x => x.Extension,
-                            new GridLength(1, GridUnitType.Star),
-                            options: new TextColumnOptions<Node>
-                            {
-                                CompareAscending = Node.SortAscending(x => x.Extension),
-                                CompareDescending = Node.SortDescending(x => x.Extension),
-                            }
-                        ),
-                        new TemplateColumn<Node>(
-                            "Size (uncompressed)",
-                            "EntrySizeCell",
-                            null,
-                            new GridLength(1, GridUnitType.Star),
-                            new TemplateColumnOptions<Node>
-                            {
-                                CompareAscending = Node.SortAscending(x => x.Size),
-                                CompareDescending = Node.SortDescending(x => x.Size),
-                                IsTextSearchEnabled = true,
-                                TextSearchValueSelector = x => x.Name,
-                            }
-                        ),
-                        // TODO: We could do an extra column for percentage of overall size,
-                        // bit of work to recalculate everything as stuff moves so cba rn
-                    },
-                };
-
-                DataGridSource.RowSelection!.SingleSelect = false;
-                DataGridSource.RowSelection!.SelectionChanged += (_, _) =>
-                    SetActiveFile(
-                        DataGridSource?.RowSelection.SelectedItems.Count > 0
-                            ? DataGridSource?.RowSelection.SelectedItems[0]
-                            : null
-                    );
+                    DataGridSource = CreateHierarchicalTreeDataGridSource();
+                    DataGridSource.RowSelection!.SingleSelect = false;
+                    DataGridSource.RowSelection!.SelectionChanged += (_, _) =>
+                        SetActiveFile(
+                            DataGridSource?.RowSelection.SelectedItems.Count > 0
+                                ? DataGridSource?.RowSelection.SelectedItems[0]
+                                : null
+                        );
+                }
             });
+    }
+
+    private HierarchicalTreeDataGridSource<Node> CreateHierarchicalTreeDataGridSource()
+    {
+        if (Tree?.Root is null)
+        {
+            throw new InvalidOperationException("Tree root cannot be null when creating data grid source");
+        }
+            
+        return new HierarchicalTreeDataGridSource<Node>(Tree.Root)
+        {
+            Columns =
+            {
+                new HierarchicalExpanderColumn<Node>(
+                    new TemplateColumn<Node>(
+                        "Name",
+                        "EntryNameCell",
+                        null, // No edit cell, doesn't work well, we use dialog window instead
+                        new GridLength(4, GridUnitType.Star),
+                        new TemplateColumnOptions<Node>
+                        {
+                            CompareAscending = Node.SortAscending(x => x.Name),
+                            CompareDescending = Node.SortDescending(x => x.Name),
+                            IsTextSearchEnabled = true,
+                            TextSearchValueSelector = x => x.Name,
+                            BeginEditGestures = BeginEditGestures.None,
+                        }
+                    ),
+                    x => x.Children,
+                    x => x.IsDirectory,
+                    x => x.IsExpanded
+                ),
+                new TextColumn<Node, string?>(
+                    "Extension",
+                    x => x.Extension,
+                    new GridLength(1, GridUnitType.Star),
+                    options: new TextColumnOptions<Node>
+                    {
+                        CompareAscending = Node.SortAscending(x => x.Extension),
+                        CompareDescending = Node.SortDescending(x => x.Extension),
+                    }
+                ),
+                new TemplateColumn<Node>(
+                    $"Size ({(ShowCompressedSize ? "compressed" : "uncompressed")})",
+                    "EntrySizeCell",
+                    null,
+                    new GridLength(1, GridUnitType.Star),
+                    new TemplateColumnOptions<Node>
+                    {
+                        CompareAscending = Node.SortAscending(x => x.Size),
+                        CompareDescending = Node.SortDescending(x => x.Size),
+                        IsTextSearchEnabled = true,
+                        TextSearchValueSelector = x => x.Name,
+                    }
+                ),
+                // TODO: We could do an extra column for percentage of overall size,
+                // bit of work to recalculate everything as stuff moves so cba rn
+            },
+        };
     }
 
     // Null here is fine, just closes RHS pane.
@@ -135,6 +150,16 @@ public sealed class PakfileExplorerViewModel : ViewModelWithView<PakfileExplorer
     public void Unsort()
     {
         DataGridSource?.Sort(null);
+    }
+
+    public void ToggleSizeDisplay()
+    {
+        ShowCompressedSize = !ShowCompressedSize;
+        Tree?.Root.NotifyDisplaySizeChanged();
+        if (Tree is not null)
+        {
+            DataGridSource = CreateHierarchicalTreeDataGridSource();
+        }
     }
 
     public void ExpandAll()

--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileTreeViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileTreeViewModel.cs
@@ -115,10 +115,15 @@ public class PakfileTreeNodeViewModel : ViewModel
         {
             bool showCompressed = Tree?.ParentViewModel?.ShowCompressedSize ?? false;
 
-            if (showCompressed && CompressedSize.HasValue && CompressedSize.Value > 0)
+            if (showCompressed)
             {
-                // Show compressed size when toggle is on
-                return FileSizeConverter.FormattedFileSize(CompressedSize.Value);
+                // When showing compressed mode, show compressed size if available
+                if (CompressedSize.HasValue && CompressedSize.Value > 0)
+                {
+                    return FileSizeConverter.FormattedFileSize(CompressedSize.Value);
+                }
+                // If no compressed size available (uncompressed entry), still show uncompressed
+                return FileSizeConverter.FormattedFileSize(Size ?? 0);
             }
             // Show uncompressed size (default)
             return FileSizeConverter.FormattedFileSize(Size ?? 0);
@@ -183,6 +188,7 @@ public class PakfileTreeNodeViewModel : ViewModel
                 Parent = this,
                 Name = path[0],
                 Size = size,
+                CompressedSize = compressedSize,
                 Tree = Tree,
             };
 
@@ -202,6 +208,7 @@ public class PakfileTreeNodeViewModel : ViewModel
             Name = path[0],
             Leaf = value,
             Size = size,
+            CompressedSize = compressedSize,
             Tree = Tree,
         };
 
@@ -292,6 +299,7 @@ public class PakfileTreeNodeViewModel : ViewModel
     public void RecalculateSize()
     {
         Size = Children?.Sum(child => child.Size) ?? 0;
+        CompressedSize = Children?.Sum(child => child.CompressedSize ?? 0) ?? 0;
     }
 
     public static Comparison<Node?> SortAscending<T>(Func<Node, T> selector)
@@ -324,7 +332,9 @@ public class PakfileTreeNodeViewModel : ViewModel
 
     public void NotifyDisplaySizeChanged()
     {
+        // Force the UI to update by raising property changed on UI thread
         this.RaisePropertyChanged(nameof(DisplaySize));
+
         if (Children != null)
         {
             foreach (PakfileTreeNodeViewModel? child in Children)

--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileTreeViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileTreeViewModel.cs
@@ -20,7 +20,10 @@ public class PakfileTreeViewModel
 
     public PakfileExplorerViewModel ParentViewModel { get; }
 
-    public PakfileTreeViewModel(SourceCache<PakfileEntryViewModel, string> source, PakfileExplorerViewModel parentViewModel)
+    public PakfileTreeViewModel(
+        SourceCache<PakfileEntryViewModel, string> source,
+        PakfileExplorerViewModel parentViewModel
+    )
     {
         ParentViewModel = parentViewModel;
         Root = new Node

--- a/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileTreeViewModel.cs
+++ b/src/Lumper.UI/ViewModels/Pages/PakfileExplorer/PakfileTreeViewModel.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reactive.Linq;
 using DynamicData;
 using DynamicData.Binding;
+using Lumper.UI.Converters;
 using Lumper.UI.Services;
 using Lumper.UI.ViewModels.Shared.Pakfile;
 using ReactiveUI;
@@ -17,13 +18,17 @@ public class PakfileTreeViewModel
 {
     public Node Root { get; }
 
-    public PakfileTreeViewModel(SourceCache<PakfileEntryViewModel, string> source)
+    public PakfileExplorerViewModel ParentViewModel { get; }
+
+    public PakfileTreeViewModel(SourceCache<PakfileEntryViewModel, string> source, PakfileExplorerViewModel parentViewModel)
     {
+        ParentViewModel = parentViewModel;
         Root = new Node
         {
             Parent = null,
             Name = BspService.Instance.FileName ?? "<no map loaded>",
             IsExpanded = true,
+            Tree = this,
         };
 
         source
@@ -84,6 +89,8 @@ public class PakfileTreeNodeViewModel : ViewModel
 
     public required Node? Parent { get; set; }
 
+    public PakfileTreeViewModel? Tree { get; set; }
+
     public ObservableCollectionExtended<Node>? Children { get; private set; }
 
     [Reactive]
@@ -93,15 +100,35 @@ public class PakfileTreeNodeViewModel : ViewModel
     public long? Size { get; set; }
 
     [Reactive]
+    public long? CompressedSize { get; set; }
+
+    [Reactive]
     public bool IsExpanded { get; set; } = false;
 
     public bool IsDirectory => Children is not null;
 
     public string? Extension => Leaf?.Extension;
 
+    public string DisplaySize
+    {
+        get
+        {
+            bool showCompressed = Tree?.ParentViewModel?.ShowCompressedSize ?? false;
+
+            if (showCompressed && CompressedSize.HasValue && CompressedSize.Value > 0)
+            {
+                // Show compressed size when toggle is on
+                return FileSizeConverter.FormattedFileSize(CompressedSize.Value);
+            }
+            // Show uncompressed size (default)
+            return FileSizeConverter.FormattedFileSize(Size ?? 0);
+        }
+    }
+
     public PakfileTreeNodeViewModel()
     {
         Size = Leaf?.UncompressedSize ?? 0;
+        CompressedSize = Leaf?.CompressedSize;
     }
 
     // Note that this is the entire path, INCLUDING name.extension
@@ -137,6 +164,7 @@ public class PakfileTreeNodeViewModel : ViewModel
     private void AddInternal(PakfileEntryViewModel? value, PathList path)
     {
         long size = value?.UncompressedSize ?? 0;
+        long compressedSize = value?.CompressedSize ?? 0;
 
         // Processing directory paths of the path, recursing down the tree and creating new nodes where needed
         if (path.Count > 1)
@@ -146,6 +174,7 @@ public class PakfileTreeNodeViewModel : ViewModel
             {
                 existing.AddInternal(value, path[1..]);
                 existing.Size += size;
+                existing.CompressedSize = (existing.CompressedSize ?? 0) + compressedSize;
                 return;
             }
 
@@ -154,6 +183,7 @@ public class PakfileTreeNodeViewModel : ViewModel
                 Parent = this,
                 Name = path[0],
                 Size = size,
+                Tree = Tree,
             };
 
             newChild.AddInternal(value, path[1..]);
@@ -172,6 +202,7 @@ public class PakfileTreeNodeViewModel : ViewModel
             Name = path[0],
             Leaf = value,
             Size = size,
+            Tree = Tree,
         };
 
         if (value is null)
@@ -289,5 +320,17 @@ public class PakfileTreeNodeViewModel : ViewModel
                 return -1;
             return Comparer<T>.Default.Compare(selector(y), selector(x));
         };
+    }
+
+    public void NotifyDisplaySizeChanged()
+    {
+        this.RaisePropertyChanged(nameof(DisplaySize));
+        if (Children != null)
+        {
+            foreach (PakfileTreeNodeViewModel? child in Children)
+            {
+                child?.NotifyDisplaySizeChanged();
+            }
+        }
     }
 }

--- a/src/Lumper.UI/Views/Pages/PakfileExplorer/PakfileExplorerView.axaml
+++ b/src/Lumper.UI/Views/Pages/PakfileExplorer/PakfileExplorerView.axaml
@@ -1,4 +1,4 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -21,7 +21,7 @@
     </Grid.ColumnDefinitions>
     <DockPanel Grid.Column="0" Classes="PageTopBar">
       <Border>
-        <Grid ColumnDefinitions="Auto, 4, Auto, *, Auto, 4, Auto, 4, Auto">
+        <Grid ColumnDefinitions="Auto, 4, Auto, *, Auto, 4, Auto, 4, Auto, 4, Auto">
           <Button Grid.Column="0" Command="{Binding ExportContents}">
             <StackPanel>
               <materialIcons:MaterialIcon Kind="Export" />
@@ -34,17 +34,22 @@
               <TextBlock>Replace</TextBlock>
             </StackPanel>
           </Button>
-          <Button Grid.Column="4" Command="{Binding Unsort}">
-            <StackPanel
-              ToolTip.Tip="Drag/drop moving isn't possible when columns are sorted. Also the up/down icons won't update when you unsort. Soz!">
+          <Button Grid.Column="4" Command="{Binding Unsort}" ToolTip.Tip="Drag/drop moving isn't possible when columns are sorted. Also the up/down icons won't update when you unsort. Soz!">
+            <StackPanel>
               <materialIcons:MaterialIcon Kind="SmileyDead" />
               <TextBlock>Unsort</TextBlock>
             </StackPanel>
           </Button>
-          <Button Grid.Column="6" Command="{Binding ExpandAll}" ToolTip.Tip="Expand All" Padding="2">
+          <Button Grid.Column="6" Command="{Binding ToggleSizeDisplay}" ToolTip.Tip="Toggle between compressed and uncompressed size display">
+            <StackPanel>
+              <materialIcons:MaterialIcon Kind="FileSwap" />
+              <TextBlock>Size</TextBlock>
+            </StackPanel>
+          </Button>
+          <Button Grid.Column="8" Command="{Binding ExpandAll}" ToolTip.Tip="Expand All" Padding="2">
             <materialIcons:MaterialIcon Kind="UnfoldMoreHorizontal" />
           </Button>
-          <Button Grid.Column="8" Command="{Binding CollapseAll}" ToolTip.Tip="Collapse All" Padding="2">
+          <Button Grid.Column="10" Command="{Binding CollapseAll}" ToolTip.Tip="Collapse All" Padding="2">
             <materialIcons:MaterialIcon Kind="UnfoldLessHorizontal" />
           </Button>
         </Grid>
@@ -62,7 +67,7 @@
             <!-- StringFormat here is a stupid hack to add space between text and scrollbar. This thing is
                              fucking annoying to style! -->
             <TextBlock
-              Text="{Binding Size, Converter={StaticResource fileSize}, StringFormat='\{0\} '} "
+              Text="{Binding DisplaySize, StringFormat='\{0\} '} "
               VerticalAlignment="Center" HorizontalAlignment="Right" />
           </DataTemplate>
         </TreeDataGrid.Resources>
@@ -76,7 +81,8 @@
         </TreeDataGrid.Styles>
       </TreeDataGrid>
     </DockPanel>
-    <GridSplitter Grid.Column="1" Width="1" MinWidth="1" ResizeDirection="Columns" />
+    <GridSplitter Grid.Column="1" Width="4" MinWidth="1" ResizeDirection="Columns" />
     <ContentControl Grid.Column="2" Content="{Binding ActiveFile}" Margin="8" />
   </Grid>
 </UserControl>
+


### PR DESCRIPTION
<img width="1028" height="139" alt="image" src="https://github.com/user-attachments/assets/52e1decf-09c2-412f-a3c0-11dd81028cfa" />

# What has Changed:
- The left pane draggable threshold is thicker now. Previously it was 1px, and trying resize the pane was a "pane" is the ass. haha.. ha.
- Fixed the unsort button having the tooltip only show up when hovering the text inside the button. The other buttons(Expand and Collapse)'s tooltips were both attached to the button. 

- Added the ability to toggle between compressed and uncompressed size values. 
<img width="988" height="566" alt="image" src="https://github.com/user-attachments/assets/4649676a-abdf-40c5-8bbc-d1b9d9f77cf9" />
<img width="975" height="580" alt="image" src="https://github.com/user-attachments/assets/d875a88f-a1e7-41c4-9042-b32e5a3070c8" />

