### PR TITLE
fix(ui): fix bitfield values being reset to 0

### DIFF
--- a/src/Lumper.UI/Controls/ExtendedAutoCompleteBox.axaml.cs
+++ b/src/Lumper.UI/Controls/ExtendedAutoCompleteBox.axaml.cs
@@ -142,8 +142,9 @@ public partial class ExtendedAutoCompleteBox : UserControl
 
         if (IsBitfieldMode)
         {
-            InitializeBitfieldCheckboxes();
-            CalculateBitfieldSum();
+            bool isValidBitfield = InitializeBitfieldCheckboxes();
+            if (isValidBitfield)
+                CalculateBitfieldSum();
         }
         else
         {
@@ -302,7 +303,7 @@ public partial class ExtendedAutoCompleteBox : UserControl
         }
     }
 
-    private void InitializeBitfieldCheckboxes()
+    private bool InitializeBitfieldCheckboxes()
     {
         _isInitializing = true;
         try
@@ -310,10 +311,10 @@ public partial class ExtendedAutoCompleteBox : UserControl
             _preservedBits = 0;
 
             if (Suggestions == null || string.IsNullOrEmpty(Text))
-                return;
+                return false;
 
             if (!long.TryParse(Text, out long currentBitfieldValue))
-                return;
+                return false;
 
             long knownMask = 0;
             foreach (ExtendedAutoCompleteItem item in Suggestions)
@@ -334,6 +335,8 @@ public partial class ExtendedAutoCompleteBox : UserControl
                         flagValue != 0 ? (currentBitfieldValue & flagValue) == flagValue : currentBitfieldValue == 0;
                 }
             }
+
+            return true;
         }
         finally
         {


### PR DESCRIPTION
When selecting multiple entities with different bitfield values ( like spawnflags ) lumper embeds `<different>` into the text field. Because that failed parsing the value was being reset to 0. I added a check to not evaluate the bitfield if parsing failed